### PR TITLE
Added boost dependency to BuildFile.xml [Closes #3]

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/test/BuildFile.xml
@@ -26,4 +26,5 @@
 <bin file="CAsizes_t.cpp">
   <use name="cuda"/>
   <use name="eigen"/>
+  <use name="boost"/>
 </bin>


### PR DESCRIPTION
#### PR description:
Fix boost dependency error in `RecoPixelVertexing/PixelTriplets/test/CAsizes_t.cpp` when added Eric's SoA template in `TrackSoAHeterogeneousT_test.h`

#### PR validation:

```bash
scram b clean
scram b -j 8
```
No boost dependency error will appear. 

Closes #3.

