### PR TITLE
update the AtomicPairCounter class

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
@@ -9,43 +9,56 @@ namespace cms::alpakatools {
 
   class AtomicPairCounter {
   public:
-    using c_type = unsigned long long int;
+    using DoubleWord = uint64_t;
 
-    ALPAKA_FN_HOST_ACC AtomicPairCounter() {}
-    ALPAKA_FN_HOST_ACC AtomicPairCounter(c_type i) { counter.ac = i; }
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter() : counter_{0} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(uint32_t first, uint32_t second) : counter_{pack(first, second)} {}
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter(DoubleWord values) : counter_{values} {}
 
-    ALPAKA_FN_HOST_ACC AtomicPairCounter& operator=(c_type i) {
-      counter.ac = i;
+    ALPAKA_FN_HOST_ACC constexpr AtomicPairCounter& operator=(DoubleWord values) {
+      counter_.as_doubleword = values;
       return *this;
     }
 
     struct Counters {
-      uint32_t n;  // in a "One to Many" association is the number of "One"
-      uint32_t m;  // in a "One to Many" association is the total number of associations
+      uint32_t first;   // in a "One to Many" association is the number of "One"
+      uint32_t second;  // in a "One to Many" association is the total number of associations
     };
 
-    union Atomic2 {
-      Counters counters;
-      c_type ac;
-    };
+    ALPAKA_FN_ACC constexpr Counters get() const { return counter_.as_counters; }
 
-    static constexpr c_type incr = 1UL << 32;
-
-    ALPAKA_FN_ACC Counters get() const { return counter.counters; }
-
-    // increment n by 1 and m by i.  return previous value
+    // atomically add as_counters, and return the previous value
     template <typename TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters add(const TAcc& acc, uint32_t i) {
-      c_type c = i;
-      c += incr;
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr Counters add(const TAcc& acc, Counters c) {
+      Packer value{pack(c.first, c.second)};
+      Packer ret{0};
+      ret.as_doubleword =
+          alpaka::atomicAdd(acc, &counter_.as_doubleword, value.as_doubleword, alpaka::hierarchy::Blocks{});
+      return ret.as_counters;
+    }
 
-      Atomic2 ret;
-      ret.ac = alpaka::atomicAdd(acc, &counter.ac, c, alpaka::hierarchy::Blocks{});
-      return ret.counters;
+    // atomically increment first and add i to second, and return the previous value
+    template <typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE Counters constexpr inc_add(const TAcc& acc, uint32_t i) {
+      return add(acc, {1u, i});
     }
 
   private:
-    Atomic2 counter;
+    union Packer {
+      DoubleWord as_doubleword;
+      Counters as_counters;
+    };
+
+    // pack two uint32_t values in a DoubleWord (aka uint64_t)
+    // this is needed because in c++17 a union can only be aggregate-initialised to its first type
+    // it can be probably removed with c++20, and replace with a designated initialiser
+    static constexpr DoubleWord pack(uint32_t first, uint32_t second) {
+      Packer ret{0};
+      ret.as_counters = {first, second};
+      return ret.as_doubleword;
+    }
+
+    Packer counter_;
   };
 
 }  // namespace cms::alpakatools

--- a/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h
@@ -209,24 +209,24 @@ namespace cms {
       template <typename TAcc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE int32_t
       bulkFill(const TAcc &acc, AtomicPairCounter &apc, index_type const *v, uint32_t n) {
-        auto c = apc.add(acc, n);
-        if (c.m >= nbins())
-          return -int32_t(c.m);
-        off[c.m] = c.n;
+        auto c = apc.inc_add(acc, n);
+        if (c.first >= nbins())
+          return -int32_t(c.first);
+        off[c.first] = c.second;
         for (uint32_t j = 0; j < n; ++j)
-          bins[c.n + j] = v[j];
-        return c.m;
+          bins[c.second + j] = v[j];
+        return c.first;
       }
 
       template <typename TAcc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void bulkFinalize(const TAcc &acc, AtomicPairCounter const &apc) {
-        off[apc.get().m] = apc.get().n;
+        off[apc.get().first] = apc.get().second;
       }
 
       template <typename TAcc>
       ALPAKA_FN_ACC ALPAKA_FN_INLINE void bulkFinalizeFill(const TAcc &acc, AtomicPairCounter const &apc) {
-        auto m = apc.get().m;
-        auto n = apc.get().n;
+        auto m = apc.get().first;
+        auto n = apc.get().second;
 
         if (m >= nbins()) {  // overflow!
           off[nbins()] = uint32_t(off[nbins() - 1]);

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
@@ -21,10 +21,10 @@ struct update {
     for_each_element_in_grid_strided(acc, n, [&](uint32_t i) {
       auto m = i % 11;
       m = m % 6 + 1;  // max 6, no 0
-      auto c = dc->add(acc, m);
-      assert(c.m < n);
-      ind[c.m] = c.n;
-      for (uint32_t j = c.n; j < c.n + m; ++j)
+      auto c = dc->inc_add(acc, m);
+      assert(c.first < n);
+      ind[c.first] = c.second;
+      for (uint32_t j = c.second; j < c.second + m; ++j)
         cont[j] = i;
     });
   }
@@ -34,8 +34,8 @@ struct finalize {
   template <typename TAcc>
   ALPAKA_FN_ACC void operator()(
       const TAcc &acc, AtomicPairCounter const *dc, uint32_t *ind, uint32_t *cont, uint32_t n) const {
-    assert(dc->get().m == n);
-    ind[n] = dc->get().n;
+    assert(dc->get().first == n);
+    ind[n] = dc->get().second;
   }
 };
 
@@ -92,8 +92,8 @@ TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestAtomicPair), s_
       // wait for all the operations to complete
       alpaka::wait(queue);
 
-      REQUIRE(c_h.data()->get().m == NUM_VALUES);
-      REQUIRE(n_h[NUM_VALUES] == c_h.data()->get().n);
+      REQUIRE(c_h.data()->get().first == NUM_VALUES);
+      REQUIRE(n_h[NUM_VALUES] == c_h.data()->get().second);
       REQUIRE(n_h[0] == 0);
 
       for (size_t i = 0; i < NUM_VALUES; ++i) {

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
@@ -125,8 +125,8 @@ struct fillBulk {
 struct verifyBulk {
   template <typename TAcc, typename Assoc>
   ALPAKA_FN_ACC void operator()(const TAcc& acc, Assoc const* __restrict__ assoc, AtomicPairCounter const* apc) const {
-    if (apc->get().m >= Assoc::nbins()) {
-      printf("Overflow %d %d\n", apc->get().m, Assoc::nbins());
+    if (apc->get().first >= Assoc::nbins()) {
+      printf("Overflow %d %d\n", apc->get().first, Assoc::nbins());
     }
     assert(assoc->size() < Assoc::capacity());
   }
@@ -262,7 +262,7 @@ int main() {
     alpaka::enqueue(queue,
                     alpaka::createTaskKernel<Acc1D>(WorkDiv1D{1u, 1u, 1u}, verifyBulk(), sa_d.data(), dc_d.data()));
 
-    std::cout << "final counter value " << dc->get().n << ' ' << dc->get().m << std::endl;
+    std::cout << "final counter value " << dc->get().second << ' ' << dc->get().first << std::endl;
 
     std::cout << la->size() << std::endl;
     imax = 0;


### PR DESCRIPTION
I would take the opportunity of the Alpaka migration to review the `AtomicPairCounter` class.

The changes I made are:
  - rename the types and members to make their meaning clearer;
  - add conversion functions and make all methods constexpr.

@VinInn you wrote the original version ages ago... does the review makes sense to you ?
See [HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h](https://github.com/PixelTracksAlpaka/cmssw/blob/567da3a098a77930be8a01139519bc4af81369c9/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h) for the whole file.