### PR TITLE
doxygen documentation for several classes/namespace

### DIFF
--- a/CalibTracker/Records/interface/SiPixelGainCalibrationForHLTSoARcd.h
+++ b/CalibTracker/Records/interface/SiPixelGainCalibrationForHLTSoARcd.h
@@ -1,0 +1,14 @@
+#ifndef CalibTracker_Records_SiPixelGainCalibrationForHLTSoARcd_h
+#define CalibTracker_Records_SiPixelGainCalibrationForHLTSoARcd_h
+
+#include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTRcd.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+class SiPixelGainCalibrationForHLTSoARcd
+    : public edm::eventsetup::DependentRecordImplementation<
+          SiPixelGainCalibrationForHLTSoARcd,
+          edm::mpl::Vector<SiPixelGainCalibrationForHLTRcd, TrackerDigiGeometryRecord>> {};
+
+#endif  // CalibTracker_Records_SiPixelGainCalibrationForHLTSoARcd_h

--- a/CalibTracker/Records/interface/SiPixelMappingSoARecord.h
+++ b/CalibTracker/Records/interface/SiPixelMappingSoARecord.h
@@ -1,0 +1,9 @@
+#ifndef CalibTracker_Records_interface_SiPixelMappingSoARecord_h
+#define CalibTracker_Records_interface_SiPixelMappingSoARecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+
+class SiPixelMappingSoARecord : public edm::eventsetup::EventSetupRecordImplementation<SiPixelMappingSoARecord> {};
+
+#endif

--- a/CalibTracker/Records/src/SiPixelGainCalibrationForHLTSoARcd.cc
+++ b/CalibTracker/Records/src/SiPixelGainCalibrationForHLTSoARcd.cc
@@ -1,0 +1,5 @@
+#include "CalibTracker/Records/interface/SiPixelGainCalibrationForHLTSoARcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+EVENTSETUP_RECORD_REG(SiPixelGainCalibrationForHLTSoARcd);

--- a/CalibTracker/Records/src/SiPixelMappingSoARcd.cc
+++ b/CalibTracker/Records/src/SiPixelMappingSoARcd.cc
@@ -1,0 +1,5 @@
+#include "CalibTracker/Records/interface/SiPixelMappingSoARecord.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+EVENTSETUP_RECORD_REG(SiPixelMappingSoARecord);

--- a/CalibTracker/SiPixelESProducers/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="alpaka"/>
 <use name="cuda"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPixelObjects"/>
@@ -6,7 +7,10 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
 <use name="HeterogeneousCore/CUDACore"/>
+<flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
@@ -1,16 +1,38 @@
-<use name="cuda"/>
-<use name="CalibTracker/Records"/>
-<use name="CalibTracker/SiPixelESProducers"/>
-<use name="CalibTracker/StandaloneTrackerTopology"/>
-<use name="CondFormats/DataRecord"/>
-<use name="CondFormats/SiPixelObjects"/>
-<use name="CondFormats/SiStripObjects"/>
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="Geometry/Records"/>
-<use name="Geometry/TrackerGeometryBuilder"/>
-<use name="MagneticField/Engine"/>
-<use name="RecoTracker/Record"/>
 <library file="*.cc" name="CalibTrackerSiPixelESProducersPlugins">
+  <use name="cuda"/>
+  <use name="CalibTracker/Records"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondFormats/SiPixelObjects"/>
+  <use name="CondFormats/SiStripObjects"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="Geometry/Records"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
+  <use name="MagneticField/Engine"/>
+  <use name="RecoTracker/Record"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="alpaka/*.cc" name="CalibTrackerSiPixelESProducersPluginsPortable">
+  <use name="alpaka"/>
+  <use name="CalibTracker/Records"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="CalibTracker/SiPixelESProducers"/>
+  <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondFormats/SiPixelObjects"/>
+  <use name="CondFormats/SiStripObjects"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="Geometry/Records"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
+  <use name="MagneticField/Engine"/>
+  <use name="RecoTracker/Record"/>
+
+  <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelCablingSoAESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelCablingSoAESProducer.cc
@@ -1,0 +1,157 @@
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingHost.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace cms::alpakatools;
+
+  class SiPixelCablingSoAESProducer : public ESProducer {
+  public:
+    SiPixelCablingSoAESProducer(edm::ParameterSet const& iConfig)
+        : ESProducer(iConfig), useQuality_(iConfig.getParameter<bool>("UseQualityInfo")) {
+      auto const& component = iConfig.getParameter<std::string>("ComponentName");
+      auto cc = setWhatProduced(this, component);
+      cablingMapToken_ = cc.consumes(edm::ESInputTag{"", iConfig.getParameter<std::string>("CablingMapLabel")});
+      if (useQuality_) {
+        qualityToken_ = cc.consumes();
+      }
+      geometryToken_ = cc.consumes();
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<std::string>("ComponentName", "");
+      desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");
+      desc.add<bool>("UseQualityInfo", false);
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    std::unique_ptr<SiPixelMappingHost> produce(const CkfComponentsRecord& iRecord) {
+      auto cablingMap = iRecord.getTransientHandle(cablingMapToken_);
+
+      const SiPixelQuality* quality = nullptr;
+      if (useQuality_) {
+        auto qualityInfo = iRecord.getTransientHandle(qualityToken_);
+        quality = qualityInfo.product();
+      }
+
+      bool hasQuality = quality != nullptr;
+      auto geom = iRecord.getTransientHandle(geometryToken_);
+      auto product = std::make_unique<SiPixelMappingHost>(
+          pixelgpudetails::MAX_SIZE,
+          cms::alpakatools::
+              host());  //(pixelgpudetails::MAX_SIZE, *(cablingMap.product()), hasQuality, cms::alpakatools::host());
+
+      std::vector<unsigned int> const& fedIds = cablingMap->fedIds();
+      std::unique_ptr<SiPixelFedCablingTree> const& cabling = cablingMap->cablingTree();
+
+      unsigned int startFed = *(fedIds.begin());
+      unsigned int endFed = *(fedIds.end() - 1);
+
+      sipixelobjects::CablingPathToDetUnit path;
+      int index = 1;
+
+      auto mapView = product->view();
+
+      mapView.hasQuality() = hasQuality;
+
+      for (unsigned int fed = startFed; fed <= endFed; fed++) {
+        for (unsigned int link = 1; link <= pixelgpudetails::MAX_LINK; link++) {
+          for (unsigned int roc = 1; roc <= pixelgpudetails::MAX_ROC; roc++) {
+            path = {fed, link, roc};
+            const sipixelobjects::PixelROC* pixelRoc = cabling->findItem(path);
+            mapView[index].fed() = fed;
+            mapView[index].link() = link;
+            mapView[index].roc() = roc;
+            if (pixelRoc != nullptr) {
+              mapView[index].rawId() = pixelRoc->rawId();
+              mapView[index].rocInDet() = pixelRoc->idInDetUnit();
+              mapView[index].modToUnpDefault() = false;
+              if (quality != nullptr)
+                mapView[index].badRocs() = quality->IsRocBad(pixelRoc->rawId(), pixelRoc->idInDetUnit());
+              else
+                mapView[index].badRocs() = false;
+            } else {  // store some dummy number
+              mapView[index].rawId() = pixelClustering::invalidModuleId;
+              mapView[index].rocInDet() = pixelClustering::invalidModuleId;
+              mapView[index].badRocs() = true;
+              mapView[index].modToUnpDefault() = true;
+            }
+            index++;
+          }
+        }
+      }  // end of FED loop
+
+      // Given FedId, Link and idinLnk; use the following formula
+      // to get the rawId and idinDU
+      // index = (FedID-1200) * MAX_LINK* MAX_ROC + (Link-1)* MAX_ROC + idinLnk;
+      // where, MAX_LINK = 48, MAX_ROC = 8
+      // FedID varies between 1200 to 1338 (In total 108 FED's)
+      // Link varies between 1 to 48
+      // idinLnk varies between 1 to 8
+
+      auto trackerGeom = iRecord.getTransientHandle(geometryToken_);
+
+      for (int i = 1; i < index; i++) {
+        if (mapView[i].rawId() == pixelClustering::invalidModuleId) {
+          mapView[i].moduleId() = pixelClustering::invalidModuleId;
+        } else {
+          /*
+          std::cout << mapView[i].rawId()[i] << std::endl;
+          */
+          auto gdet = trackerGeom->idToDetUnit(mapView[i].rawId());
+          if (!gdet) {
+            LogDebug("SiPixelCablingSoAESProducer") << " Not found: " << mapView[i].rawId() << std::endl;
+            continue;
+          }
+          mapView[i].moduleId() = gdet->index();
+        }
+        LogDebug("SiPixelCablingSoAESProducer")
+            << "----------------------------------------------------------------------------" << std::endl;
+        LogDebug("SiPixelCablingSoAESProducer") << i << std::setw(20) << mapView[i].fed() << std::setw(20)
+                                                << mapView[i].link() << std::setw(20) << mapView[i].roc() << std::endl;
+        LogDebug("SiPixelCablingSoAESProducer")
+            << i << std::setw(20) << mapView[i].rawId() << std::setw(20) << mapView[i].rocInDet() << std::setw(20)
+            << mapView[i].moduleId() << std::endl;
+        LogDebug("SiPixelCablingSoAESProducer")
+            << i << std::setw(20) << mapView[i].badRocs() << std::setw(20) << std::endl;
+        LogDebug("SiPixelCablingSoAESProducer")
+            << "----------------------------------------------------------------------------" << std::endl;
+      }
+
+      mapView.size() = index - 1;
+
+      return product;
+    }
+
+  private:
+    edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
+    edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> qualityToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geometryToken_;
+    bool useQuality_;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(SiPixelCablingSoAESProducer);

--- a/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelGainCalibrationForHLTSoAESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/alpaka/SiPixelGainCalibrationForHLTSoAESProducer.cc
@@ -1,0 +1,123 @@
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTHost.h"
+#include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <memory>
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class SiPixelGainCalibrationForHLTSoAESProducer : public ESProducer {
+  public:
+    explicit SiPixelGainCalibrationForHLTSoAESProducer(const edm::ParameterSet& iConfig);
+    std::unique_ptr<SiPixelGainCalibrationForHLTHost> produce(const SiPixelGainCalibrationForHLTSoARcd& iRecord);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    edm::ESGetToken<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTRcd> gainsToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geometryToken_;
+  };
+
+  SiPixelGainCalibrationForHLTSoAESProducer::SiPixelGainCalibrationForHLTSoAESProducer(
+      const edm::ParameterSet& iConfig) : ESProducer(iConfig) {
+    auto cc = setWhatProduced(this);
+    gainsToken_ = cc.consumes();
+    geometryToken_ = cc.consumes();
+  }
+
+  void SiPixelGainCalibrationForHLTSoAESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    //descriptions.add("siPixelGainCalibrationForHLTSoA", desc);
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  std::unique_ptr<SiPixelGainCalibrationForHLTHost> SiPixelGainCalibrationForHLTSoAESProducer::produce(
+      const SiPixelGainCalibrationForHLTSoARcd& iRecord) {
+    auto gainsRecord = iRecord.getHandle(gainsToken_);
+    auto geomRecord = iRecord.getHandle(geometryToken_);
+
+    auto geom = *(geomRecord);
+    auto gains = *(gainsRecord);
+
+    auto product = std::make_unique<SiPixelGainCalibrationForHLTHost>(gains.data().size(), cms::alpakatools::host());
+
+    // bizzarre logic (looking for fist strip-det) don't ask
+    auto const& dus = geom.detUnits();
+    unsigned int n_detectors = dus.size();
+    for (unsigned int i = 1; i < 7; ++i) {
+      const auto offset = geom.offsetDU(GeomDetEnumerators::tkDetEnum[i]);
+      if (offset != dus.size() && dus[offset]->type().isTrackerStrip()) {
+        if (n_detectors > offset)
+          n_detectors = offset;
+      }
+    }
+
+    //LogDebug("SiPixelGainCalibrationForHLTSoA")
+    std::cout << "caching calibs for " << n_detectors << " pixel detectors of size " << gains.data().size() << '\n'
+              << "sizes " << sizeof(char) << ' ' << sizeof(uint8_t) << ' '
+              << sizeof(siPixelGainsSoA::DecodingStructure);
+
+    // &(product->view().v_pedestals()) = (siPixelGainsSoA::DecodingStructure*)gains.data().data();
+    //std::copy here
+    // do not read back from the (possibly write-combined) memory buffer
+    auto minPed = gains.getPedLow();
+    auto maxPed = gains.getPedHigh();
+    auto minGain = gains.getGainLow();
+    auto maxGain = gains.getGainHigh();
+    auto nBinsToUseForEncoding = 253;
+
+    // we will simplify later (not everything is needed....)
+    product->view().minPed() = minPed;
+    product->view().maxPed() = maxPed;
+    product->view().minGain() = minGain;
+    product->view().maxGain() = maxGain;
+
+    product->view().numberOfRowsAveragedOver() = 80;
+    product->view().nBinsToUseForEncoding() = nBinsToUseForEncoding;
+    product->view().deadFlag() = 255;
+    product->view().noisyFlag() = 254;
+
+    product->view().pedPrecision() = static_cast<float>(maxPed - minPed) / nBinsToUseForEncoding;
+    product->view().gainPrecision() = static_cast<float>(maxGain - minGain) / nBinsToUseForEncoding;
+
+    LogDebug("SiPixelGainCalibrationForHLTSoA")
+        << "precisions g " << product->view().pedPrecision() << ' ' << product->view().gainPrecision();
+
+    // fill the index map
+    auto const& ind = gains.getIndexes();
+    LogDebug("SiPixelGainCalibrationForHLTSoA") << ind.size() << " " << n_detectors;
+
+    for (auto i = 0U; i < n_detectors; ++i) {
+      auto p = std::lower_bound(
+          ind.begin(), ind.end(), dus[i]->geographicalId().rawId(), SiPixelGainCalibrationForHLT::StrictWeakOrdering());
+      assert(p != ind.end() && p->detid == dus[i]->geographicalId());
+      assert(p->iend <= gains.data().size());
+      assert(p->iend >= p->ibegin);
+      assert(0 == p->ibegin % 2);
+      assert(0 == p->iend % 2);
+      assert(p->ibegin != p->iend);
+      assert(p->ncols > 0);
+      product->view().rangeAndCols()[i] = std::make_pair(siPixelGainsSoA::Range(p->ibegin, p->iend), p->ncols);
+      if (ind[i].detid != dus[i]->geographicalId())
+        LogDebug("SiPixelGainCalibrationForHLTSoA") << ind[i].detid << "!=" << dus[i]->geographicalId();
+    }
+
+    return product;
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(SiPixelGainCalibrationForHLTSoAESProducer);

--- a/CalibTracker/SiPixelESProducers/src/ES_SiPixelGainCalibrationForHLTSoA.cc
+++ b/CalibTracker/SiPixelESProducers/src/ES_SiPixelGainCalibrationForHLTSoA.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(SiPixelGainCalibrationForHLTHost);

--- a/CalibTracker/SiPixelESProducers/src/ES_SiPixelMappingSoA.cc
+++ b/CalibTracker/SiPixelESProducers/src/ES_SiPixelMappingSoA.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(SiPixelMappingHost);

--- a/CalibTracker/SiPixelESProducers/src/alpaka/ES_SiPixelGainCalibrationForHLTSoA.cc
+++ b/CalibTracker/SiPixelESProducers/src/alpaka/ES_SiPixelGainCalibrationForHLTSoA.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+TYPELOOKUP_ALPAKA_DATA_REG(SiPixelGainCalibrationForHLTDevice);

--- a/CalibTracker/SiPixelESProducers/src/alpaka/ES_SiPixelMappingSoA.cc
+++ b/CalibTracker/SiPixelESProducers/src/alpaka/ES_SiPixelMappingSoA.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+TYPELOOKUP_ALPAKA_DATA_REG(SiPixelMappingDevice);

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="alpaka"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="CalibFormats/SiPixelObjects"/>
@@ -12,6 +13,8 @@
 <use name="FWCore/MessageLogger"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="Geometry/CommonTopologies"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTHost.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTHost.h
@@ -1,0 +1,9 @@
+#ifndef CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTHost_h
+#define CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTHost_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+
+using SiPixelGainCalibrationForHLTHost = PortableHostCollection<SiPixelGainCalibrationForHLTLayout<>>;
+
+#endif  // CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTHost_h

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h
@@ -1,0 +1,40 @@
+#ifndef CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTLayout_h
+#define CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTLayout_h
+
+#include <array>
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+namespace siPixelGainsSoA {
+  struct DecodingStructure {
+    uint8_t gain;
+    uint8_t ped;
+  };
+
+  using Range = std::pair<uint32_t, uint32_t>;
+  using RangeAndCols = std::array<std::pair<Range, int>, phase1PixelTopology::numberOfModules>;
+
+}  // namespace siPixelGainsSoA
+
+GENERATE_SOA_LAYOUT(SiPixelGainCalibrationForHLTLayout,
+                    SOA_COLUMN(siPixelGainsSoA::DecodingStructure, v_pedestals),
+                    SOA_SCALAR(siPixelGainsSoA::RangeAndCols, rangeAndCols),
+
+                    SOA_SCALAR(float, minPed),
+                    SOA_SCALAR(float, maxPed),
+                    SOA_SCALAR(float, minGain),
+                    SOA_SCALAR(float, maxGain),
+                    SOA_SCALAR(float, pedPrecision),
+                    SOA_SCALAR(float, gainPrecision),
+
+                    SOA_SCALAR(unsigned int, numberOfRowsAveragedOver),
+                    SOA_SCALAR(unsigned int, nBinsToUseForEncoding),
+                    SOA_SCALAR(unsigned int, deadFlag),
+                    SOA_SCALAR(unsigned int, noisyFlag),
+                    SOA_SCALAR(float, link))
+
+using SiPixelGainCalibrationForHLTSoA = SiPixelGainCalibrationForHLTLayout<>;
+using SiPixelGainCalibrationForHLTSoAView = SiPixelGainCalibrationForHLTLayout<>::View;
+using SiPixelGainCalibrationForHLTSoAConstView = SiPixelGainCalibrationForHLTLayout<>::ConstView;
+
+#endif  // CondFormats_SiPixelObjects_SiPixelGainCalibrationForHLTLayout_h

--- a/CondFormats/SiPixelObjects/interface/SiPixelMappingHost.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelMappingHost.h
@@ -1,0 +1,10 @@
+#ifndef CondFormats_SiPixelObjects_SiPixelMappingHost_h
+#define CondFormats_SiPixelObjects_SiPixelMappingHost_h
+
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h"
+
+using SiPixelMappingHost = PortableHostCollection<SiPixelMappingLayout<>>;
+
+#endif  // CondFormats_SiPixelObjects_SiPixelMappingHost_h

--- a/CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h
@@ -1,0 +1,24 @@
+#ifndef CondFormats_SiPixelObjects_SiPixelMappingLayout_h
+#define CondFormats_SiPixelObjects_SiPixelMappingLayout_h
+
+#include <array>
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelROCsStatusAndMapping.h"
+
+GENERATE_SOA_LAYOUT(SiPixelMappingLayout,
+                    SOA_COLUMN(unsigned int, fed),
+                    SOA_COLUMN(unsigned int, link),
+                    SOA_COLUMN(unsigned int, roc),
+                    SOA_COLUMN(unsigned int, rawId),
+                    SOA_COLUMN(unsigned int, rocInDet),
+                    SOA_COLUMN(unsigned int, moduleId),
+                    SOA_COLUMN(bool, badRocs),
+                    SOA_COLUMN(unsigned char, modToUnpDefault),
+                    SOA_SCALAR(unsigned int, size),
+                    SOA_SCALAR(bool, hasQuality))
+
+using SiPixelMappingLayoutSoA = SiPixelMappingLayout<>;
+using SiPixelMappingLayoutSoAView = SiPixelMappingLayout<>::View;
+using SiPixelMappingLayoutSoAConstView = SiPixelMappingLayout<>::ConstView;
+
+#endif  // CondFormats_SiPixelObjects_SiPixelMappingLayout_h

--- a/CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h
+++ b/CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h
@@ -1,0 +1,14 @@
+#ifndef CondFormats_SiPixelObjects_alpaka_SiPixelGainCalibrationForHLTDevice_h
+#define CondFormats_SiPixelObjects_alpaka_SiPixelGainCalibrationForHLTDevice_h
+
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using SiPixelGainCalibrationForHLTDevice = PortableCollection<SiPixelGainCalibrationForHLTLayout<>>;
+  using SiPixelGainCalibrationForHLTHost = PortableHostCollection<SiPixelGainCalibrationForHLTLayout<>>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+#endif  // CondFormats_SiPixelObjects_alpaka_SiPixelGainCalibrationForHLTDevice_h

--- a/CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTUtilities.h
+++ b/CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTUtilities.h
@@ -1,0 +1,43 @@
+
+#ifndef CondFormats_SiPixelObjects_alpaka_SiPixelGainUtilities_h
+#define CondFormats_SiPixelObjects_alpaka_SiPixelGainUtilities_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+
+struct SiPixelGainUtilities {
+  ALPAKA_FN_HOST_ACC ALPAKA_FN_ACC ALPAKA_FN_INLINE static std::pair<float, float> getPedAndGain(
+      const SiPixelGainCalibrationForHLTSoAConstView& view,
+      uint32_t moduleInd,
+      int col,
+      int row,
+      bool& isDeadColumn,
+      bool& isNoisyColumn) {
+    auto range = view.rangeAndCols()[moduleInd].first;
+    auto nCols = view.rangeAndCols()[moduleInd].second;
+    // determine what averaged data block we are in (there should be 1 or 2 of these depending on if plaquette is 1 by X or 2 by X
+    unsigned int lengthOfColumnData = (range.second - range.first) / nCols;
+    unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block
+    unsigned int numberOfDataBlocksToSkip = row / view.numberOfRowsAveragedOver();
+
+    auto offset = range.first + col * lengthOfColumnData + lengthOfAveragedDataInEachColumn * numberOfDataBlocksToSkip;
+
+    assert(offset < range.second);
+    assert(offset < 3088384);
+    assert(0 == offset % 2);
+
+    auto lp = view.v_pedestals();
+    auto s = lp[offset / 2];
+
+    isDeadColumn = (s.ped & 0xFF) == view.deadFlag();
+    isNoisyColumn = (s.ped & 0xFF) == view.noisyFlag();
+
+    float decodePed = float(s.gain & 0xFF) * view.gainPrecision() + view.minGain();
+    float decodeGain = float(s.ped & 0xFF) * view.pedPrecision() + view.minPed();
+
+    return std::make_pair(decodePed, decodeGain);
+  };
+};
+
+#endif  //CondFormats_SiPixelObjects_alpaka_SiPixelGainUtilities_h

--- a/CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h
+++ b/CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h
@@ -1,0 +1,18 @@
+#ifndef DataFormats_SiPixelMappingSoA_alpaka_SiPixelClustersDevice_h
+#define DataFormats_SiPixelMappingSoA_alpaka_SiPixelClustersDevice_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using SiPixelMappingDevice = PortableCollection<SiPixelMappingLayout<>>;
+  using SiPixelMappingHost = PortableHostCollection<SiPixelMappingLayout<>>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // DataFormats_SiPixelMappingSoA_alpaka_SiPixelClustersDevice_h

--- a/CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingUtilities.h
+++ b/CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingUtilities.h
@@ -1,0 +1,54 @@
+
+#ifndef CondFormats_SiPixelObjects_alpaka_SiPixelMappingUtilities_h
+#define CondFormats_SiPixelObjects_alpaka_SiPixelMappingUtilities_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  struct SiPixelMappingUtilities {
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_ACC ALPAKA_FN_INLINE static bool hasQuality(
+        const SiPixelMappingLayoutSoAConstView& view) {
+      return view.hasQuality();
+    }
+
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_ACC ALPAKA_FN_INLINE static cms::alpakatools::device_buffer<Device, unsigned char[]>
+    getModToUnpRegionalAsync(std::set<unsigned int> const& modules,
+                             const SiPixelFedCablingTree* cabling,
+                             std::vector<unsigned int> const& fedIds,
+                             Queue& queue) {
+      auto modToUnpDevice = cms::alpakatools::make_device_buffer<unsigned char[]>(queue, pixelgpudetails::MAX_SIZE);
+      auto modToUnpHost = cms::alpakatools::make_host_buffer<unsigned char[]>(queue, pixelgpudetails::MAX_SIZE);
+
+      unsigned int startFed = fedIds.front();
+      unsigned int endFed = fedIds.back();
+
+      sipixelobjects::CablingPathToDetUnit path;
+      int index = 1;
+
+      for (unsigned int fed = startFed; fed <= endFed; fed++) {
+        for (unsigned int link = 1; link <= pixelgpudetails::MAX_LINK; link++) {
+          for (unsigned int roc = 1; roc <= pixelgpudetails::MAX_ROC; roc++) {
+            path = {fed, link, roc};
+            const sipixelobjects::PixelROC* pixelRoc = cabling->findItem(path);
+            if (pixelRoc != nullptr) {
+              modToUnpHost[index] = (not modules.empty()) and (modules.find(pixelRoc->rawId()) == modules.end());
+            } else {  // store some dummy number
+              modToUnpHost[index] = true;
+            }
+            index++;
+          }
+        }
+      }
+
+      alpaka::memcpy(queue, modToUnpDevice, modToUnpHost);
+
+      return modToUnpDevice;
+    }
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+#endif  //CondFormats_SiPixelObjects_alpaka_SiPixelMappingUtilities_h

--- a/DataFormats/BeamSpotAlpaka/BuildFile.xml
+++ b/DataFormats/BeamSpotAlpaka/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="alpaka"/>
+<use name="rootcore"/>
+<use name="DataFormats/BeamSpot"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="serial"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h
+++ b/DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_BeamSpotAlpaka_interface_alpaka_BeamSpotAlpaka_h
+#define DataFormats_BeamSpotAlpaka_interface_alpaka_BeamSpotAlpaka_h
+
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  class BeamSpotAlpaka {
+  public:
+    // default constructor, required by cms::alpakatools::Product<BeamSpotAlpaka>
+    BeamSpotAlpaka() = default;
+
+    // constructor that allocates cached device memory on the given CUDA stream
+    BeamSpotAlpaka(Queue& queue) : data_d_{cms::alpakatools::make_device_buffer<BeamSpotPOD>(queue)} {}
+
+    // movable, non-copiable
+    BeamSpotAlpaka(BeamSpotAlpaka const&) = delete;
+    BeamSpotAlpaka(BeamSpotAlpaka&&) = default;
+    BeamSpotAlpaka& operator=(BeamSpotAlpaka const&) = delete;
+    BeamSpotAlpaka& operator=(BeamSpotAlpaka&&) = default;
+
+    BeamSpotPOD* data() { return data_d_->data(); }
+    BeamSpotPOD const* data() const { return data_d_->data(); }
+
+    cms::alpakatools::device_buffer<Device, BeamSpotPOD>& ptr() { return *data_d_; }
+    cms::alpakatools::device_buffer<Device, BeamSpotPOD> const& ptr() const { return *data_d_; }
+
+  private:
+    std::optional<cms::alpakatools::device_buffer<Device, BeamSpotPOD>> data_d_;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // DataFormats_BeamSpotAlpaka_interface_alpaka_BeamSpotAlpaka_h

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_BeamSpotAlpaka_alpaka_classes_cuda_h
+#define DataFormats_BeamSpotAlpaka_alpaka_classes_cuda_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+
+#endif

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda.h
@@ -2,7 +2,6 @@
 #define DataFormats_BeamSpotAlpaka_alpaka_classes_cuda_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
 

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,6 @@
+<!-- TODO: Unused class rule -->
+<lcgdict>
+  <class name="alpaka_cuda_async::BeamSpotAlpaka>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::BeamSpotAlpaka>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::BeamSpotAlpaka>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_BeamSpotAlpaka_alpaka_classes_rocm_h
+#define DataFormats_BeamSpotAlpaka_alpaka_classes_rocm_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+
+#endif

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm.h
@@ -2,7 +2,6 @@
 #define DataFormats_BeamSpotAlpaka_alpaka_classes_rocm_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
 

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,6 @@
+
+<lcgdict>
+  <class name="alpaka_rocm_async::BeamSpotAlpaka>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_rocm_async::BeamSpotAlpaka>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_rocm_async::BeamSpotAlpaka>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_BeamSpotAlpaka_alpaka_classes_serial_h
+#define DataFormats_BeamSpotAlpaka_alpaka_classes_serial_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+
+#endif

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial.h
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial.h
@@ -2,7 +2,6 @@
 #define DataFormats_BeamSpotAlpaka_alpaka_classes_serial_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
 

--- a/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/BeamSpotAlpaka/src/alpaka/classes_serial_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="alpaka_serial_sync::BeamSpotAlpaka" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_serial_sync::BeamSpotAlpaka>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/BeamSpotAlpaka/src/classes.h
+++ b/DataFormats/BeamSpotAlpaka/src/classes.h
@@ -1,0 +1,6 @@
+#ifndef DataFormats_BeamSpotAlpaka_classes_h
+#define DataFormats_BeamSpotAlpaka_classes_h
+
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+
+#endif  // DataFormats_BeamSpotAlpaka_classes_h

--- a/DataFormats/BeamSpotAlpaka/src/classes_def.xml
+++ b/DataFormats/BeamSpotAlpaka/src/classes_def.xml
@@ -1,0 +1,5 @@
+<!-- <lcgdict>
+  <class name="cms::alpakatools::Product<BeamSpotAlpaka>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<BeamSpotAlpaka>>" persistent="false"/>
+</lcgdict> -->
+  

--- a/DataFormats/Portable/interface/HostProductAlpaka.h
+++ b/DataFormats/Portable/interface/HostProductAlpaka.h
@@ -1,0 +1,31 @@
+#ifndef DataFormats_Common_interface_HostProduct_H
+#define DataFormats_Common_interface_HostProduct_H
+
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+// a heterogeneous unique pointer...
+template <typename T>
+class HostProductAlpaka {
+public:
+  HostProductAlpaka() = default;  // make root happy
+  ~HostProductAlpaka() = default;
+  HostProductAlpaka(HostProductAlpaka&&) = default;
+  HostProductAlpaka& operator=(HostProductAlpaka&&) = default;
+
+  explicit HostProductAlpaka(cms::alpakatools::host_buffer<T>&& p) : hm_ptr(std::move(p)) {}
+  explicit HostProductAlpaka(std::unique_ptr<T>&& p) : std_ptr(std::move(p)) {}
+
+  auto const* get() const { return std_ptr ? std_ptr.get() : hm_ptr.data(); }
+
+  auto const& operator*() const { return *get(); }
+
+  auto const* operator->() const { return get(); }
+
+private:
+  cms::alpakatools::host_buffer<T> hm_ptr;  //!
+  std::unique_ptr<T> std_ptr;               //!
+};
+
+#endif

--- a/DataFormats/SiPixelClusterSoA/BuildFile.xml
+++ b/DataFormats/SiPixelClusterSoA/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="alpaka"/>
+<use name="rootcore"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate" source_only="1"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
+<export>
+    <lib name="1"/>
+</export>

--- a/DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
+++ b/DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
@@ -1,0 +1,28 @@
+#ifndef DataFormats_SiPixelClusterSoA_ClusteringConstants_h
+#define DataFormats_SiPixelClusterSoA_ClusteringConstants_h
+
+#include <cstdint>
+#include <limits>
+//TODO: move this to TrackerTraits!
+namespace pixelClustering {
+#ifdef GPU_SMALL_EVENTS
+  // kept for testing and debugging
+  constexpr uint32_t maxHitsInIter() { return 64; }
+#else
+  // optimized for real data PU 50
+  // tested on MC events with 55-75 pileup events
+  constexpr uint32_t maxHitsInIter() { return 160; }  //TODO better tuning for PU 140-200
+#endif
+  constexpr uint32_t maxHitsInModule() { return 1024; }
+
+  constexpr uint32_t maxNumDigis = 3 * 256 * 1024;  // @PU=200 µ=530k σ=50k this is >4σ away
+  constexpr uint16_t maxNumModules = 4000;
+
+  constexpr int32_t maxNumClustersPerModules = maxHitsInModule();
+  constexpr uint16_t invalidModuleId = std::numeric_limits<uint16_t>::max() - 1;
+  constexpr int invalidClusterId = -9999;
+  static_assert(invalidModuleId > maxNumModules);  // invalidModuleId must be > maxNumModules
+
+}  // namespace pixelClustering
+
+#endif  // DataFormats_SiPixelClusterSoA_ClusteringConstants_h

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h
@@ -1,0 +1,38 @@
+#ifndef DataFormats_SiPixelClusterSoA_SiPixelClustersHost_h
+#define DataFormats_SiPixelClusterSoA_SiPixelClustersHost_h
+
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+#include "SiPixelClustersLayout.h"
+
+// TODO: The class is created via inheritance of the PortableCollection.
+// This is generally discouraged, and should be done via composition.
+// See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
+class SiPixelClustersHost : public PortableHostCollection<SiPixelClustersLayout<>> {
+public:
+  SiPixelClustersHost() = default;
+  ~SiPixelClustersHost() = default;
+
+  template <typename TQueue>
+  explicit SiPixelClustersHost(size_t maxModules, TQueue queue)
+      : PortableHostCollection<SiPixelClustersLayout<>>(maxModules + 1, queue) {}
+
+  SiPixelClustersHost(SiPixelClustersHost &&) = default;
+  SiPixelClustersHost &operator=(SiPixelClustersHost &&) = default;
+
+  void setNClusters(uint32_t nClusters, int32_t offsetBPIX2) {
+    nClusters_h = nClusters;
+    offsetBPIX2_h = offsetBPIX2;
+  }
+
+  uint32_t nClusters() const { return nClusters_h; }
+  int32_t offsetBPIX2() const { return offsetBPIX2_h; }
+
+private:
+  uint32_t nClusters_h = 0;
+  int32_t offsetBPIX2_h = 0;
+};
+
+#endif  // DataFormats_SiPixelClusterSoA_SiPixelClustersHost_h

--- a/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h
+++ b/DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h
@@ -1,0 +1,16 @@
+#ifndef DataFormats_SiPixelClusterSoA_SiPixelClustersLayout_h
+#define DataFormats_SiPixelClusterSoA_SiPixelClustersLayout_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SiPixelClustersLayout,
+                    SOA_COLUMN(uint32_t, moduleStart),
+                    SOA_COLUMN(uint32_t, clusInModule),
+                    SOA_COLUMN(uint32_t, moduleId),
+                    SOA_COLUMN(uint32_t, clusModuleStart))
+
+using SiPixelClustersLayoutSoA = SiPixelClustersLayout<>;
+using SiPixelClustersLayoutSoAView = SiPixelClustersLayout<>::View;
+using SiPixelClustersLayoutSoAConstView = SiPixelClustersLayout<>::ConstView;
+
+#endif  // DataFormats_SiPixelClusterSoA_SiPixelClustersLayout_h

--- a/DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h
+++ b/DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h
@@ -1,0 +1,55 @@
+#ifndef DataFormats_SiPixelClusterSoA_SiPixelClustersDevice_h
+#define DataFormats_SiPixelClusterSoA_SiPixelClustersDevice_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+
+// TODO: The class is created via inheritance of the PortableCollection.
+// This is generally discouraged, and should be done via composition.
+// See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  class SiPixelClustersDevice : public PortableCollection<SiPixelClustersLayout<>> {
+  public:
+    SiPixelClustersDevice() = default;
+    ~SiPixelClustersDevice() = default;
+
+    template <typename TQueue>
+    explicit SiPixelClustersDevice(size_t maxModules, TQueue queue)
+        : PortableCollection<SiPixelClustersLayout<>>(maxModules + 1, queue) {}
+
+    SiPixelClustersDevice(SiPixelClustersDevice &&) = default;
+    SiPixelClustersDevice &operator=(SiPixelClustersDevice &&) = default;
+
+    void setNClusters(uint32_t nClusters, int32_t offsetBPIX2) {
+      nClusters_h = nClusters;
+      offsetBPIX2_h = offsetBPIX2;
+    }
+
+    uint32_t nClusters() const { return nClusters_h; }
+    int32_t offsetBPIX2() const { return offsetBPIX2_h; }
+
+  private:
+    uint32_t nClusters_h = 0;
+    int32_t offsetBPIX2_h = 0;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelClustersDevice> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue &queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelClustersDevice const &srcData) {
+      SiPixelClustersHost dstData(srcData->metadata().size(), queue);
+      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      dstData.setNClusters(srcData.nClusters(), srcData.offsetBPIX2());
+      return dstData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif  // DataFormats_SiPixelClusterSoA_SiPixelClustersDevice_h

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda.h
@@ -2,7 +2,6 @@
 #define DataFormats_SiPixelClusterSoA_alpaka_Classes_CUDA_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
 #include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
 

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelClusterSoA_alpaka_Classes_CUDA_h
+#define DataFormats_SiPixelClusterSoA_alpaka_Classes_CUDA_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+
+#endif  // DataFormats_Track_src_alpaka_classes_cuda_h

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::SiPixelClustersDevice" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::SiPixelClustersDevice>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::SiPixelClustersDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelClusterSoA_alpaka_Classes_rocm_h
+#define DataFormats_SiPixelClusterSoA_alpaka_Classes_rocm_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+
+#endif  // DataFormats_Track_src_alpaka_classes_rocm_h

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm.h
@@ -2,7 +2,6 @@
 #define DataFormats_SiPixelClusterSoA_alpaka_Classes_rocm_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
 #include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
 

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::SiPixelClustersDevice" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::SiPixelClustersDevice>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::SiPixelClustersDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_serial.h
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_serial.h
@@ -1,0 +1,8 @@
+#ifndef DataFormats_SiPixelClusterSoA_alpaka_classes_serial_h
+#define DataFormats_SiPixelClusterSoA_alpaka_classes_serial_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+
+#endif  // DataFormats_Track_src_alpaka_classes_serial_h

--- a/DataFormats/SiPixelClusterSoA/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/alpaka/classes_serial_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="alpaka_serial_sync::SiPixelClustersDevice" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_serial_sync::SiPixelClustersDevice>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelClusterSoA/src/classes.h
+++ b/DataFormats/SiPixelClusterSoA/src/classes.h
@@ -1,0 +1,8 @@
+#ifndef DataFormats_SiPixelClusterSoA_src_classes_h
+#define DataFormats_SiPixelClusterSoA_src_classes_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
+
+#endif  // DataFormats_SiPixelClusterSoA_src_classes_h

--- a/DataFormats/SiPixelClusterSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelClusterSoA/src/classes_def.xml
@@ -1,0 +1,19 @@
+<lcgdict>
+  <class name="SiPixelClustersLayoutSoA"/>
+  <class name="SiPixelClustersLayoutSoA::View"/>
+  <class name="PortableHostCollection<SiPixelClustersLayoutSoA>"/>
+  <read
+    sourceClass="PortableHostCollection<SiPixelClustersLayoutSoA>"
+    targetClass="PortableHostCollection<SiPixelClustersLayoutSoA>"
+    version="[1-]"
+    source="SiPixelClustersLayoutSoA layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<SiPixelClustersLayoutSoA>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+
+  <class name="SiPixelClustersHost"/>
+  <class name="edm::Wrapper<SiPixelClustersHost>" splitLevel="0"/>
+</lcgdict>

--- a/DataFormats/SiPixelClusterSoA/test/BuildFile.xml
+++ b/DataFormats/SiPixelClusterSoA/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<bin file="alpaka/Clusters_test.cc alpaka/Clusters_test.dev.cc" name="Clusters_test">
+  <use name="alpaka"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="DataFormats/SiPixelClusterSoa" source_only="1"/>
+<flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.cc
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.cc
@@ -1,0 +1,45 @@
+#include <alpaka/alpaka.hpp>
+#include <unistd.h>
+
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace testClusterSoA {
+
+    void runKernels(SiPixelClustersLayoutSoAView clust_view, Queue& queue);
+  }
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+int main() {
+  const auto host = cms::alpakatools::host();
+  const auto device = cms::alpakatools::devices<Platform>()[0];
+  Queue queue(device);
+
+  // Inner scope to deallocate memory before destroying the stream
+  {
+    // Instantiate tracks on device. PortableDeviceCollection allocates
+    // SoA on device automatically.
+    SiPixelClustersDevice clusters_d(100, queue);
+    testClusterSoA::runKernels(clusters_d.view(), queue);
+
+    // Instantate tracks on host. This is where the data will be
+    // copied to from device.
+    SiPixelClustersHost clusters_h(clusters_d.view().metadata().size(), queue);
+
+    std::cout << clusters_h.view().metadata().size() << std::endl;
+    alpaka::memcpy(queue, clusters_h.buffer(), clusters_d.const_buffer());
+    alpaka::wait(queue);
+  }
+
+  return 0;
+}

--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
@@ -1,0 +1,48 @@
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+using namespace alpaka;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace cms::alpakatools;
+  namespace testClusterSoA {
+
+    class TestFillKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersLayoutSoAView clust_view) const {
+        for (int32_t j : elements_with_stride(acc, clust_view.metadata().size())) {
+          clust_view[j].moduleStart() = j;
+          clust_view[j].clusInModule() = j * 2;
+          clust_view[j].moduleId() = j * 3;
+          clust_view[j].clusModuleStart() = j * 4;
+        }
+      }
+    };
+
+    class TestVerifyKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersLayoutSoAConstView clust_view) const {
+        for (uint32_t j : elements_with_stride(acc, clust_view.metadata().size())) {
+          assert(clust_view[j].moduleStart() == j);
+          assert(clust_view[j].clusInModule() == j * 2);
+          assert(clust_view[j].moduleId() == j * 3);
+          assert(clust_view[j].clusModuleStart() == j * 4);
+        }
+      }
+    };
+
+    void runKernels(SiPixelClustersLayoutSoAView clust_view, Queue& queue) {
+      uint32_t items = 64;
+      uint32_t groups = divide_up_by(clust_view.metadata().size(), items);
+      auto workDiv = make_workdiv<Acc1D>(groups, items);
+      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, clust_view);
+      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, clust_view);
+    }
+
+  }  // namespace testClusterSoA
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/DataFormats/SiPixelDigiSoA/BuildFile.xml
+++ b/DataFormats/SiPixelDigiSoA/BuildFile.xml
@@ -1,0 +1,11 @@
+<use name="alpaka"/>
+<use name="rootcore"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SiPixelRawData"/>
+<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
+<export>
+    <lib name="1"/>
+</export>

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
@@ -1,0 +1,41 @@
+#ifndef DataFormats_SiPixelDigi_SiPixelDigiErrorsAlpaka_h
+#define DataFormats_SiPixelDigi_SiPixelDigiErrorsAlpaka_h
+
+#include <utility>
+
+#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+
+class SiPixelDigiErrorsHost {
+public:
+  SiPixelDigiErrorsHost() = default;
+  ~SiPixelDigiErrorsHost() = default;
+  explicit SiPixelDigiErrorsHost(int nErrorWords,
+                                 SiPixelFormatterErrors errors,
+                                 cms::alpakatools::host_buffer<SiPixelErrorCompact[]> data)
+      : nErrorWords_(nErrorWords), formatterErrors_h{std::move(errors)} {
+    data_h = std::move(data);
+    error_h = cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>();
+    (*error_h).data()->set_data((*data_h).data());
+  }
+
+  int nErrorWords() const { return nErrorWords_; }
+
+  cms::alpakatools::SimpleVector<SiPixelErrorCompact>* error() { return (*error_h).data(); }
+  cms::alpakatools::SimpleVector<SiPixelErrorCompact> const* error() const { return (*error_h).data(); }
+  auto& error_data() { return (*data_h); }
+  auto const& error_data() const { return (*data_h); }
+
+  const SiPixelFormatterErrors& formatterErrors() const { return formatterErrors_h; }
+
+private:
+  int nErrorWords_ = 0;
+  SiPixelFormatterErrors formatterErrors_h;
+  std::optional<cms::alpakatools::host_buffer<SiPixelErrorCompact[]>> data_h;
+  std::optional<cms::alpakatools::host_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>> error_h;
+};
+
+#endif  // AlpakaDataFormats_alpaka_SiPixelDigiErrorsAlpaka_h

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
@@ -7,7 +7,7 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
-#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 
 class SiPixelDigiErrorsHost {
 public:

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisErrorLayout.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisErrorLayout.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_SiPixelDigi_SiPixelDigisErrorLayout_h
+#define DataFormats_SiPixelDigi_SiPixelDigisErrorLayout_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+
+GENERATE_SOA_LAYOUT(SiPixelDigisErrorLayout, SOA_COLUMN(SiPixelErrorCompact, pixelErrors))
+
+using SiPixelDigisErrorLayoutSoA = SiPixelDigisErrorLayout<>;
+using SiPixelDigisErrorLayoutSoAView = SiPixelDigisErrorLayout<>::View;
+using SiPixelDigisErrorLayoutSoAConstView = SiPixelDigisErrorLayout<>::ConstView;
+
+#endif  // DataFormats_SiPixelDigi_SiPixelDigisErrorLayout_h

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
@@ -1,0 +1,36 @@
+#ifndef DataFormats_SiPixelDigi_SiPixelDigisHost_h
+#define DataFormats_SiPixelDigi_SiPixelDigisHost_h
+
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+
+#include "SiPixelDigisLayout.h"
+
+// TODO: The class is created via inheritance of the PortableDeviceCollection.
+// This is generally discouraged, and should be done via composition.
+// See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
+class SiPixelDigisHost : public PortableHostCollection<SiPixelDigisLayout<>> {
+public:
+  SiPixelDigisHost() = default;
+  template <typename TQueue>
+  explicit SiPixelDigisHost(size_t maxFedWords, TQueue queue)
+      : PortableHostCollection<SiPixelDigisLayout<>>(maxFedWords + 1, queue) {}
+  ~SiPixelDigisHost() = default;
+
+  SiPixelDigisHost(SiPixelDigisHost &&) = default;
+  SiPixelDigisHost &operator=(SiPixelDigisHost &&) = default;
+
+  void setNModulesDigis(uint32_t nModules, uint32_t nDigis) {
+    nModules_h = nModules;
+    nDigis_h = nDigis;
+  }
+
+  uint32_t nModules() const { return nModules_h; }
+  uint32_t nDigis() const { return nDigis_h; }
+
+private:
+  uint32_t nModules_h = 0;
+  uint32_t nDigis_h = 0;
+};
+
+#endif  // DataFormats_SiPixelDigi_SiPixelDigisHost_h

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_SiPixelDigi_SiPixelDigisLayout_h
+#define DataFormats_SiPixelDigi_SiPixelDigisLayout_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SiPixelDigisLayout,
+                    SOA_COLUMN(int32_t, clus),
+                    SOA_COLUMN(uint32_t, pdigi),
+                    SOA_COLUMN(uint32_t, rawIdArr),
+                    SOA_COLUMN(uint16_t, adc),
+                    SOA_COLUMN(uint16_t, xx),
+                    SOA_COLUMN(uint16_t, yy),
+                    SOA_COLUMN(uint16_t, moduleId))
+
+using SiPixelDigisLayoutSoA = SiPixelDigisLayout<>;
+using SiPixelDigisLayoutSoAView = SiPixelDigisLayout<>::View;
+using SiPixelDigisLayoutSoAConstView = SiPixelDigisLayout<>::ConstView;
+
+#endif  // DataFormats_SiPixelDigi_SiPixelDigisLayout_h

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h
@@ -1,0 +1,75 @@
+#ifndef AlpakaDataFormats_alpaka_SiPixelDigiErrorsAlpaka_h
+#define AlpakaDataFormats_alpaka_SiPixelDigiErrorsAlpaka_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class SiPixelDigiErrorsDevice {
+  public:
+    explicit SiPixelDigiErrorsDevice(size_t maxFedWords, SiPixelFormatterErrors errors, Queue& queue)
+        : maxFedWords_(maxFedWords), formatterErrors_h{std::move(errors)} {
+      data_d = cms::alpakatools::make_device_buffer<SiPixelErrorCompact[]>(queue, maxFedWords);
+      error_d = cms::alpakatools::make_device_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>(queue);
+      (*error_d).data()->construct(maxFedWords, data_d->data());
+      ALPAKA_ASSERT_OFFLOAD((*error_d).data()->empty());
+      ALPAKA_ASSERT_OFFLOAD((*error_d).data()->capacity() == static_cast<int>(maxFedWords));
+    }
+    SiPixelDigiErrorsDevice() = default;
+    ~SiPixelDigiErrorsDevice() = default;
+
+    SiPixelDigiErrorsDevice(const SiPixelDigiErrorsDevice&) = delete;
+    SiPixelDigiErrorsDevice& operator=(const SiPixelDigiErrorsDevice&) = delete;
+    SiPixelDigiErrorsDevice(SiPixelDigiErrorsDevice&&) = default;
+    SiPixelDigiErrorsDevice& operator=(SiPixelDigiErrorsDevice&&) = default;
+
+    const SiPixelFormatterErrors& formatterErrors() const { return formatterErrors_h; }
+
+    cms::alpakatools::SimpleVector<SiPixelErrorCompact>* error() { return (*error_d).data(); }
+    cms::alpakatools::SimpleVector<SiPixelErrorCompact> const* error() const { return (*error_d).data(); }
+    cms::alpakatools::SimpleVector<SiPixelErrorCompact> const* c_error() const { return (*error_d).data(); }
+
+    auto& error_vector() const { return (*error_d); }
+    auto& error_data() const { return (*data_d); }
+    auto maxFedWords() const { return maxFedWords_; }
+
+  private:
+    int maxFedWords_;
+    SiPixelFormatterErrors formatterErrors_h;
+    std::optional<cms::alpakatools::device_buffer<Device, SiPixelErrorCompact[]>> data_d;
+    std::optional<cms::alpakatools::device_buffer<Device, cms::alpakatools::SimpleVector<SiPixelErrorCompact>>> error_d;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsDevice> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsDevice const& srcData) {
+      auto error_vector = srcData.error_vector();
+      auto error_data_h = cms::alpakatools::make_host_buffer<SiPixelErrorCompact[]>(error_vector.data()->capacity());
+      auto error_data = srcData.error_data();
+
+      if (not error_vector->empty()) {
+        alpaka::memcpy(queue, error_data_h, error_data);
+      }
+
+      SiPixelDigiErrorsHost dstData(error_vector.data()->capacity(), srcData.formatterErrors(), error_data_h);
+
+      // alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      return dstData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif  // DataFormats_alpaka_SiPixelDigiErrorsDevice_h

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h
@@ -9,7 +9,7 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
-#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h
@@ -1,0 +1,53 @@
+#ifndef DataFormats_SiPixelDigi_interface_SiPixelDigisDevice_h
+#define DataFormats_SiPixelDigi_interface_SiPixelDigisDevice_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class SiPixelDigisDevice : public PortableCollection<SiPixelDigisLayout<>> {
+  public:
+    SiPixelDigisDevice() = default;
+    template <typename TQueue>
+    explicit SiPixelDigisDevice(size_t maxFedWords, TQueue queue)
+        : PortableCollection<SiPixelDigisLayout<>>(maxFedWords + 1, queue) {}
+    ~SiPixelDigisDevice() = default;
+
+    SiPixelDigisDevice(SiPixelDigisDevice &&) = default;
+    SiPixelDigisDevice &operator=(SiPixelDigisDevice &&) = default;
+
+    void setNModulesDigis(uint32_t nModules, uint32_t nDigis) {
+      nModules_h = nModules;
+      nDigis_h = nDigis;
+    }
+
+    uint32_t nModules() const { return nModules_h; }
+    uint32_t nDigis() const { return nDigis_h; }
+
+  private:
+    uint32_t nModules_h = 0;
+    uint32_t nDigis_h = 0;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisDevice> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue &queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisDevice const &srcData) {
+      SiPixelDigisHost dstData(srcData.view().metadata().size(), queue);
+      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      dstData.setNModulesDigis(srcData.nModules(), srcData.nDigis());
+      return dstData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+// }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+#endif  // DataFormats_SiPixelDigi_interface_SiPixelDigisDevice_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
@@ -2,7 +2,6 @@
 #define DataFormats_SiPixelDigiSoA_alpaka_classes_cuda_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
 

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelDigiSoA_alpaka_classes_cuda_h
+#define DataFormats_SiPixelDigiSoA_alpaka_classes_cuda_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+
+#endif  // DataFormats_SiPixelDigiSoA_src_alpaka_classes_cuda_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,6 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::SiPixelDigisDevice" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_cuda_async::SiPixelDigisDevice>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::SiPixelDigisDevice>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::SiPixelDigisDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelDigiSoA_alpaka_classes_rocm_h
+#define DataFormats_SiPixelDigiSoA_alpaka_classes_rocm_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+
+#endif  // DataFormats_SiPixelDigiSoA_alpaka_classes_rocm_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
@@ -2,7 +2,6 @@
 #define DataFormats_SiPixelDigiSoA_alpaka_classes_rocm_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
 

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,6 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::SiPixelDigisDevice" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_rocm_async::SiPixelDigisDevice>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::SiPixelDigisDevice>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::SiPixelDigisDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_serial.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_serial.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelDigiSoA_alpaka_alasses_serial_h
+#define DataFormats_SiPixelDigiSoA_alpaka_alasses_serial_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h"
+
+#endif  // DataFormats_SiPixelDigiSoA_alpaka_classes_serial_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_serial_def.xml
@@ -1,0 +1,7 @@
+<lcgdict>
+  <class name="alpaka_serial_sync::SiPixelDigisDevice" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_serial_sync::SiPixelDigisDevice>" persistent="false"/>
+
+  <class name="alpaka_serial_sync::SiPixelDigiErrorsDevice" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_serial_sync::SiPixelDigiErrorsDevice>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/classes.h
+++ b/DataFormats/SiPixelDigiSoA/src/classes.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_SiPixelDigiSoA_src_classes_h
+#define DataFormats_SiPixelDigiSoA_src_classes_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
+
+#endif  // DataFormats_SiPixelDigiSoA_src_classes_h

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -1,0 +1,21 @@
+<lcgdict>
+  <class name="SiPixelDigisLayoutSoA"/>
+  <class name="SiPixelDigisLayoutSoA::View"/>
+  <class name="PortableHostCollection<SiPixelDigisLayoutSoA>"/>
+  <read
+    sourceClass="PortableHostCollection<SiPixelDigisLayoutSoA>"
+    targetClass="PortableHostCollection<SiPixelDigisLayoutSoA>"
+    version="[1-]"
+    source="SiPixelDigisLayoutSoA layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<SiPixelDigisLayoutSoA>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+
+  <class name="SiPixelDigisHost"/>
+  <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>
+  <class name="SiPixelDigiErrorsHost"/>
+  <class name="edm::Wrapper<SiPixelDigiErrorsHost>" splitLevel="0"/>
+</lcgdict>

--- a/DataFormats/SiPixelDigiSoA/test/BuildFile.xml
+++ b/DataFormats/SiPixelDigiSoA/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<bin file="alpaka/Digis_test.cc alpaka/Digis_test.dev.cc" name="Digis_test">
+  <use name="alpaka"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
@@ -1,0 +1,46 @@
+#include <alpaka/alpaka.hpp>
+#include <unistd.h>
+
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace testDigisSoA {
+
+    void runKernels(SiPixelDigisLayoutSoAView digis_view, Queue& queue);
+  }
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+int main() {
+  const auto host = cms::alpakatools::host();
+  const auto device = cms::alpakatools::devices<Platform>()[0];
+  Queue queue(device);
+
+  // Inner scope to deallocate memory before destroying the stream
+  {
+    // Instantiate tracks on device. PortableDeviceCollection allocates
+    // SoA on device automatically.
+    SiPixelDigisDevice digis_d(1000, queue);
+    testDigisSoA::runKernels(digis_d.view(), queue);
+
+    // Instantate tracks on host. This is where the data will be
+    // copied to from device.
+    SiPixelDigisHost digis_h(digis_d.view().metadata().size(), queue);
+
+    std::cout << digis_h.view().metadata().size() << std::endl;
+    alpaka::memcpy(queue, digis_h.buffer(), digis_d.const_buffer());
+    alpaka::wait(queue);
+  }
+
+  return 0;
+}

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
@@ -1,0 +1,48 @@
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+using namespace alpaka;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace cms::alpakatools;
+  namespace testDigisSoA {
+
+    class TestFillKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisLayoutSoAView digi_view) const {
+        for (int32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
+          digi_view[j].clus() = j;
+          digi_view[j].rawIdArr() = j * 2;
+          digi_view[j].xx() = j * 3;
+          digi_view[j].moduleId() = j * 4;
+        }
+      }
+    };
+
+    class TestVerifyKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisLayoutSoAConstView digi_view) const {
+        for (uint32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
+          assert(digi_view[j].clus() == int(j));
+          assert(digi_view[j].rawIdArr() == j * 2);
+          assert(digi_view[j].xx() == j * 3);
+          assert(digi_view[j].moduleId() == j * 4);
+        }
+      }
+    };
+
+    void runKernels(SiPixelDigisLayoutSoAView digi_view, Queue& queue) {
+      uint32_t items = 64;
+      uint32_t groups = divide_up_by(digi_view.metadata().size(), items);
+      auto workDiv = make_workdiv<Acc1D>(groups, items);
+      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, digi_view);
+      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, digi_view);
+    }
+
+  }  // namespace testDigisSoA
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/DataFormats/TrackingRecHitSoA/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/BuildFile.xml
@@ -1,0 +1,13 @@
+<use name="alpaka"/>
+<use name="rootcore"/>
+<use name="eigen"/>
+<use name="DataFormats/SiPixelClusterSoA"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/TrackerCommon" source_only="1"/>
+<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="HeterogeneousCore/AlpakaUtilities"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
+<export>
+    <lib name="1"/>
+</export>

--- a/DataFormats/TrackingRecHitSoA/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackerCommon" source_only="1"/>
 <use name="DataFormats/SoATemplate" source_only="1"/>
-<use name="HeterogeneousCore/AlpakaUtilities"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="cuda rocm"/>
 <export>

--- a/DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h
+++ b/DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h
@@ -1,0 +1,20 @@
+#ifndef DataFormats_TrackingRecHitSoA_SiPixelHitStatus_H
+#define DataFormats_TrackingRecHitSoA_SiPixelHitStatus_H
+
+#include <cstdint>
+
+// more information on bit fields : https://en.cppreference.com/w/cpp/language/bit_field
+struct SiPixelHitStatus {
+  bool isBigX : 1;   //  ∈[0,1]
+  bool isOneX : 1;   //  ∈[0,1]
+  bool isBigY : 1;   //  ∈[0,1]
+  bool isOneY : 1;   //  ∈[0,1]
+  uint8_t qBin : 3;  //  ∈[0,1,...,7]
+};
+
+struct SiPixelHitStatusAndCharge {
+  SiPixelHitStatus status;
+  uint32_t charge : 24;
+};
+
+#endif

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h
@@ -1,0 +1,52 @@
+#ifndef DataFormats_RecHits_TrackingRecHitsHost_h
+#define DataFormats_RecHits_TrackingRecHitsHost_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+template <typename TrackerTraits>
+class TrackingRecHitAlpakaHost : public PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>> {
+public:
+  using hitSoA = TrackingRecHitAlpakaSoA<TrackerTraits>;
+  //Need to decorate the class with the inherited portable accessors being now a template
+  using PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::view;
+  using PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::const_view;
+  using PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::buffer;
+  // using PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::bufferSize;
+
+  TrackingRecHitAlpakaHost() = default;
+
+  using AverageGeometry = typename hitSoA::AverageGeometry;
+  using ParamsOnDevice = typename hitSoA::ParamsOnDevice;
+  using PhiBinnerStorageType = typename hitSoA::PhiBinnerStorageType;
+  using PhiBinner = typename hitSoA::PhiBinner;
+
+  // This SoA Host is used basically only for DQM
+  // so we  just need a slim constructor
+  explicit TrackingRecHitAlpakaHost(uint32_t nHits)
+      : PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>(nHits) {}
+
+  template <typename TQueue>
+  explicit TrackingRecHitAlpakaHost(uint32_t nHits, TQueue queue)
+      : PortableHostCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>(nHits, queue) {}
+
+  uint32_t nHits() const { return nHits_; }
+  uint32_t offsetBPIX2() const { return offsetBPIX2_; }
+  auto phiBinnerStorage() { return phiBinnerStorage_; }
+
+private:
+  uint32_t nHits_;  //Needed for the host SoA size
+  ParamsOnDevice const* cpeParams_;
+  uint32_t offsetBPIX2_;
+
+  PhiBinnerStorageType* phiBinnerStorage_;
+};
+
+using TrackingRecHitAlpakaHostPhase1 = TrackingRecHitAlpakaHost<pixelTopology::Phase1>;
+using TrackingRecHitAlpakaHostPhase2 = TrackingRecHitAlpakaHost<pixelTopology::Phase2>;
+
+#endif  // CUDADataFormats_Track_TrackHeterogeneousT_H

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h
@@ -1,0 +1,67 @@
+#ifndef DataFormats_RecHits_TrackingRecHitsLayout_h
+#define DataFormats_RecHits_TrackingRecHitsLayout_h
+
+#include <Eigen/Dense>
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "SiPixelHitStatus.h"
+
+template <typename TrackerTraits>
+struct TrackingRecHitAlpakaSoA {
+  using hindex_type = typename TrackerTraits::hindex_type;
+  using PhiBinner = cms::alpakatools::HistoContainer<int16_t,
+                                                     256,
+                                                     500000,
+                                                     8 * sizeof(int16_t),
+                                                     hindex_type,
+                                                     TrackerTraits::numberOfLayers>;  //28 for phase2 geometry
+
+  using PhiBinnerStorageType = typename PhiBinner::index_type;
+  using AverageGeometry = pixelTopology::AverageGeometryT<TrackerTraits>;
+  using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
+
+  using HitLayerStartArray = std::array<hindex_type, TrackerTraits::numberOfLayers + 1>;
+  using HitModuleStartArray = std::array<hindex_type, TrackerTraits::numberOfModules + 1>;
+
+  //Is it better to have two split?
+  GENERATE_SOA_LAYOUT(TrackingRecHitAlpakaSoALayout,
+                      SOA_COLUMN(float, xLocal),
+                      SOA_COLUMN(float, yLocal),
+                      SOA_COLUMN(float, xerrLocal),
+                      SOA_COLUMN(float, yerrLocal),
+                      SOA_COLUMN(float, xGlobal),
+                      SOA_COLUMN(float, yGlobal),
+                      SOA_COLUMN(float, zGlobal),
+                      SOA_COLUMN(float, rGlobal),
+                      SOA_COLUMN(int16_t, iphi),
+                      SOA_COLUMN(SiPixelHitStatusAndCharge, chargeAndStatus),
+                      SOA_COLUMN(int16_t, clusterSizeX),
+                      SOA_COLUMN(int16_t, clusterSizeY),
+                      SOA_COLUMN(uint16_t, detectorIndex),
+
+                      SOA_SCALAR(uint32_t, nHits),
+                      SOA_SCALAR(int32_t, offsetBPIX2),
+                      //These above could be separated in a specific
+                      //layout since they don't depends on the template
+                      //for the moment I'm keeping them here
+                      SOA_COLUMN(PhiBinnerStorageType, phiBinnerStorage),
+                      SOA_SCALAR(HitModuleStartArray, hitsModuleStart),
+                      SOA_SCALAR(HitLayerStartArray, hitsLayerStart),
+                      SOA_SCALAR(ParamsOnDevice, cpeParams),
+                      SOA_SCALAR(AverageGeometry, averageGeometry),
+                      SOA_SCALAR(PhiBinner, phiBinner));
+};
+
+template <typename TrackerTraits>
+using TrackingRecHitAlpakaLayout =
+    typename TrackingRecHitAlpakaSoA<TrackerTraits>::template TrackingRecHitAlpakaSoALayout<>;
+template <typename TrackerTraits>
+using TrackingRecHitAlpakaSoAView =
+    typename TrackingRecHitAlpakaSoA<TrackerTraits>::template TrackingRecHitAlpakaSoALayout<>::View;
+template <typename TrackerTraits>
+using TrackingRecHitAlpakaSoAConstView =
+    typename TrackingRecHitAlpakaSoA<TrackerTraits>::template TrackingRecHitAlpakaSoALayout<>::ConstView;
+
+#endif

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h
@@ -3,7 +3,7 @@
 
 #include <Eigen/Dense>
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
 #include "SiPixelHitStatus.h"

--- a/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h
+++ b/DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h
@@ -1,0 +1,112 @@
+#ifndef DataFormats_RecHits_TrackingRecHitsDevice_h
+#define DataFormats_RecHits_TrackingRecHitsDevice_h
+
+#include <cstdint>
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  template <typename TrackerTraits>
+  class TrackingRecHitAlpakaDevice : public PortableCollection<TrackingRecHitAlpakaLayout<TrackerTraits>> {
+  public:
+    using hitSoA = TrackingRecHitAlpakaSoA<TrackerTraits>;
+    //Need to decorate the class with the inherited portable accessors being now a template
+    using PortableCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::view;
+    using PortableCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::const_view;
+    using PortableCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>::buffer;
+
+    TrackingRecHitAlpakaDevice() = default;
+
+    using AverageGeometry = typename hitSoA::AverageGeometry;
+    using ParamsOnDevice = typename hitSoA::ParamsOnDevice;
+    using PhiBinnerStorageType = typename hitSoA::PhiBinnerStorageType;
+    using PhiBinner = typename hitSoA::PhiBinner;
+    // Constructor which specifies the SoA size
+    template <typename TQueue>
+    explicit TrackingRecHitAlpakaDevice(uint32_t nHits,
+                                        int32_t offsetBPIX2,
+                                        ParamsOnDevice const* cpeParams,
+                                        uint32_t const* hitsModuleStart,
+                                        TQueue queue)
+        : PortableCollection<TrackingRecHitAlpakaLayout<TrackerTraits>>(nHits, queue),
+          nHits_(nHits),
+          cpeParams_(cpeParams),
+          hitsModuleStart_(hitsModuleStart),
+          offsetBPIX2_(offsetBPIX2) {
+      phiBinner_ = &(view().phiBinner());
+
+      const auto& host = cms::alpakatools::host();
+      const auto device = alpaka::getDev(queue);
+
+      auto cpe_h = alpaka::createView(host, cpeParams, 1);
+      auto cpe_d = alpaka::createView(device, &(view().cpeParams()), 1);
+      alpaka::memcpy(queue, cpe_d, cpe_h, 1);
+
+      auto start_h = alpaka::createView(host, hitsModuleStart, TrackerTraits::numberOfModules + 1);
+      auto start_d = alpaka::createView(device, view().hitsModuleStart().data(), TrackerTraits::numberOfModules + 1);
+      alpaka::memcpy(queue, start_d, start_h);
+
+      // auto nHits_d = alpaka::createView(device, &(view().nHits()), 1);
+      // alpaka::memset(queue, nHits_d, nHits);
+
+      auto nHits_h = alpaka::createView(host, &nHits, 1);
+      auto nHits_d = alpaka::createView(device, &(view().nHits()), 1);
+      alpaka::memcpy(queue, nHits_d, nHits_h, 1);
+
+      auto off_h = alpaka::createView(host, &offsetBPIX2, 1);
+      auto off_d = alpaka::createView(device, &(view().offsetBPIX2()), 1);
+      alpaka::memcpy(queue, off_d, off_h, 1);
+    }
+
+    uint32_t nHits() const { return nHits_; }  //go to size of view
+
+    auto phiBinnerStorage() { return phiBinnerStorage_; }
+    auto hitsModuleStart() const { return hitsModuleStart_; }
+    uint32_t offsetBPIX2() const { return offsetBPIX2_; }
+    auto phiBinner() { return phiBinner_; }
+
+  private:
+    uint32_t nHits_;  //Needed for the host SoA size
+
+    //TODO: this is used not that much from the hits (only once in BrokenLineFit), would make sens to remove it from this class.
+    ParamsOnDevice const* cpeParams_;
+    uint32_t const* hitsModuleStart_;
+    uint32_t offsetBPIX2_;
+
+    PhiBinnerStorageType* phiBinnerStorage_;
+    PhiBinner* phiBinner_;
+  };
+
+  //Classes definition for Phase1/Phase2, to make the classes_def lighter. Not actually used in the code.
+  using TrackingRecHitAlpakaDevicePhase1 = TrackingRecHitAlpakaDevice<pixelTopology::Phase1>;
+  using TrackingRecHitAlpakaDevicePhase2 = TrackingRecHitAlpakaDevice<pixelTopology::Phase2>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::TrackingRecHitAlpakaDevicePhase1> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue,
+                          ALPAKA_ACCELERATOR_NAMESPACE::TrackingRecHitAlpakaDevicePhase1 const& deviceData) {
+      TrackingRecHitAlpakaHostPhase1 hostData(deviceData.view().metadata().size(), queue);
+      alpaka::memcpy(queue, hostData.buffer(), deviceData.buffer());
+      return hostData;
+    }
+  };
+
+  template <>
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::TrackingRecHitAlpakaDevicePhase2> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue,
+                          ALPAKA_ACCELERATOR_NAMESPACE::TrackingRecHitAlpakaDevicePhase2 const& deviceData) {
+      TrackingRecHitAlpakaHostPhase2 hostData(deviceData.view().metadata().size(), queue);
+      alpaka::memcpy(queue, hostData.buffer(), deviceData.buffer());
+      return hostData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif  // CUDADataFormats_Track_TrackHeterogeneousT_H

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_TrackingRecHitSoA_alpaka_classes_cuda_h
+#define DataFormats_TrackingRecHitSoA_alpaka_classes_cuda_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+
+#endif  // DataFormats_Track_alpaka_classes_cuda_h

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda.h
@@ -2,8 +2,7 @@
 #define DataFormats_TrackingRecHitSoA_alpaka_classes_cuda_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
 #include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
 
-#endif  // DataFormats_Track_alpaka_classes_cuda_h
+#endif  // DataFormats_TrackingRecHitSoA_alpaka_classes_cuda_h

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,12 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase1" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase1>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase1>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase1>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase2" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase2>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase2>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::TrackingRecHitAlpakaDevicePhase2>>" persistent="false"/>
+
+</lcgdict>

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm.h
@@ -2,7 +2,6 @@
 #define DataFormats_TrackingRecHitSoA_alpaka_classes_rocm_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
 #include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
 

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm.h
@@ -1,0 +1,9 @@
+#ifndef DataFormats_TrackingRecHitSoA_alpaka_classes_rocm_h
+#define DataFormats_TrackingRecHitSoA_alpaka_classes_rocm_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+
+#endif  // DataFormats_Track_alpaka_classes_rocm_h

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,12 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase1" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase1>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase1>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase1>>" persistent="false"/>
+
+  <class name="alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase2" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase2>" persistent="false"/>
+  <class name="cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase2>" persistent="false"/>
+  <class name="edm::Wrapper<cms::alpakatools::Product<alpaka_rocm_async::Queue,alpaka_rocm_async::TrackingRecHitAlpakaDevicePhase2>>" persistent="false"/>
+
+</lcgdict>

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial.h
@@ -2,7 +2,6 @@
 #define DataFormats_TrackingRecHitSoA_alpaka_classes_serial_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
 

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial.h
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial.h
@@ -1,0 +1,11 @@
+#ifndef DataFormats_TrackingRecHitSoA_alpaka_classes_serial_h
+#define DataFormats_TrackingRecHitSoA_alpaka_classes_serial_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+
+using namespace pixelTopology;
+
+#endif  // DataFormats_TrackingRecHitSoA_alpaka_classes_serial_h

--- a/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/alpaka/classes_serial_def.xml
@@ -1,0 +1,31 @@
+<lcgdict>
+  <!-- <class name="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"/>
+  <read
+    sourceClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"
+    targetClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"
+    version="[1-]"
+    source="TrackingRecHitAlpakaLayout<pixelTopology::Phase1> layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="TrackingRecHitAlpakaHostPhase1"/>
+  <class name="edm::Wrapper<TrackingRecHitAlpakaHostPhase1>" splitLevel="0"/>
+
+  <class name="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"/>
+  <read
+    sourceClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"
+    targetClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"
+    version="[1-]"
+    source="TrackingRecHitAlpakaLayout<pixelTopology::Phase2> layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="TrackingRecHitAlpakaHostPhase2"/>
+  <class name="edm::Wrapper<TrackingRecHitAlpakaHostPhase2>" splitLevel="0"/> -->
+</lcgdict>

--- a/DataFormats/TrackingRecHitSoA/src/classes.h
+++ b/DataFormats/TrackingRecHitSoA/src/classes.h
@@ -1,0 +1,11 @@
+#ifndef DataFormats_TrackingRecHitSoA_classes_h
+#define DataFormats_TrackingRecHitSoA_classes_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+
+using namespace pixelTopology;
+
+#endif  // DataFormats_TrackingRecHitSoA_classes_h

--- a/DataFormats/TrackingRecHitSoA/src/classes.h
+++ b/DataFormats/TrackingRecHitSoA/src/classes.h
@@ -2,7 +2,6 @@
 #define DataFormats_TrackingRecHitSoA_classes_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
 

--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -1,0 +1,39 @@
+<lcgdict>
+  <class name="TrackingRecHitAlpakaSoA<pixelTopology::Phase1>"/>
+  <class name="TrackingRecHitAlpakaLayout<pixelTopology::Phase1>"/>
+  <class name="TrackingRecHitAlpakaSoAView<pixelTopology::Phase1>"/>
+
+  <class name="TrackingRecHitAlpakaSoA<pixelTopology::Phase2>"/>
+  <class name="TrackingRecHitAlpakaLayout<pixelTopology::Phase2>"/>
+  <class name="TrackingRecHitAlpakaSoAView<pixelTopology::Phase2>"/>
+
+    <class name="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"/>
+  <read
+    sourceClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"
+    targetClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>"
+    version="[1-]"
+    source="TrackingRecHitAlpakaLayout<pixelTopology::Phase1> layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase1>>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="TrackingRecHitAlpakaHostPhase1"/>
+  <class name="edm::Wrapper<TrackingRecHitAlpakaHostPhase1>" splitLevel="0"/>
+
+  <class name="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"/>
+  <read
+    sourceClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"
+    targetClass="PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>"
+    version="[1-]"
+    source="TrackingRecHitAlpakaLayout<pixelTopology::Phase2> layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    PortableHostCollection<TrackingRecHitAlpakaLayout<pixelTopology::Phase2>>::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="TrackingRecHitAlpakaHostPhase2"/>
+  <class name="edm::Wrapper<TrackingRecHitAlpakaHostPhase2>" splitLevel="0"/>
+</lcgdict>

--- a/DataFormats/TrackingRecHitSoA/test/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<use name="eigen"/>
+<bin file="alpaka/Hits_test.cc alpaka/Hits_test.dev.cc" name="Hits_test">
+  <use name="alpaka"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.cc
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.cc
@@ -1,0 +1,50 @@
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+#include <alpaka/alpaka.hpp>
+#include <unistd.h>
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace testTrackingRecHitSoA {
+
+    template <typename TrackerTraits>
+    void runKernels(TrackingRecHitAlpakaSoAView<TrackerTraits>& hits, Queue& queue);
+
+  }
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+int main() {
+  /*  const auto host = cms::alpakatools::host();
+  const auto device = cms::alpakatools::devices<Platform>()[0];
+  Queue queue(device);
+
+  using ParamsOnDevice = TrackingRecHitAlpakaDevice<pixelTopology::Phase1>::ParamsOnDevice;
+  // inner scope to deallocate memory before destroying the queue
+  {
+    uint32_t nHits = 2000;
+    int32_t offset = 100;
+    uint32_t moduleStart[1856];
+
+    for (size_t i = 0; i < 1856; i++) {
+      moduleStart[i] = i * 2;
+    }
+    auto cpeParams = std::make_unique<ParamsOnDevice>();
+    TrackingRecHitAlpakaDevice<pixelTopology::Phase1> tkhit(nHits, offset, cpeParams.get(), &moduleStart[0], queue);
+
+    testTrackingRecHitSoA::runKernels<pixelTopology::Phase1>(tkhit.view(), queue);
+    alpaka::wait(queue);
+  }
+*/
+  return 0;
+}

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
@@ -1,0 +1,66 @@
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+using namespace alpaka;
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using namespace cms::alpakatools;
+  namespace testTrackingRecHitSoA {
+
+    template <typename TrackerTraits>
+    class TestFillKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, TrackingRecHitAlpakaSoAView<TrackerTraits> soa) const {
+        const uint32_t i(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+        const uint32_t j(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+
+        if (i == 0 and j == 0) {
+          soa.offsetBPIX2() = 22;
+          soa[10].xLocal() = 1.11;
+        }
+
+        soa[i].iphi() = i % 10;
+        soa.hitsLayerStart()[j] = j;
+      }
+    };
+
+    template <typename TrackerTraits>
+    class ShowKernel {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, TrackingRecHitAlpakaSoAConstView<TrackerTraits> soa) const {
+        const uint32_t i(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+        const uint32_t j(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+
+        if (i == 0 and j == 0) {
+          printf("nbins = %d \n", soa.phiBinner().nbins());
+          printf("offsetBPIX %d ->%d \n", i, soa.offsetBPIX2());
+          printf("nHits %d ->%d \n", i, soa.nHits());
+          //printf("hitsModuleStart %d ->%d \n", i, soa.hitsModuleStart().at(28));
+        }
+
+        if (i < 10)  // can be increased to soa.nHits() for debugging
+          printf("iPhi %d ->%d \n", i, soa[i].iphi());
+      }
+    };
+
+    template <typename TrackerTraits>
+    void runKernels(TrackingRecHitAlpakaSoAView<TrackerTraits>& view, Queue& queue) {
+      uint32_t items = 64;
+      uint32_t groups = divide_up_by(view.metadata().size(), items);
+      auto workDiv = make_workdiv<Acc1D>(groups, items);
+      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel<TrackerTraits>{}, view);
+      alpaka::exec<Acc1D>(queue, workDiv, ShowKernel<TrackerTraits>{}, view);
+    }
+
+    template void runKernels<pixelTopology::Phase1>(TrackingRecHitAlpakaSoAView<pixelTopology::Phase1>& view,
+                                                    Queue& queue);
+    template void runKernels<pixelTopology::Phase2>(TrackingRecHitAlpakaSoAView<pixelTopology::Phase2>& view,
+                                                    Queue& queue);
+
+  }  // namespace testTrackingRecHitSoA
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalTracker/SiPixelClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/BuildFile.xml
@@ -1,0 +1,11 @@
+<use name="FWCore/Framework"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousCore/AlpakaTest"/>
+<use name="CalibTracker/Records"/>
+<use name="CalibTracker/SiPixelESProducers"/>
+<use name="CondFormats/SiPixelObjects"/>
+<flags ALPAKA_BACKENDS="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -29,7 +29,6 @@
   <use name="FWCore/Framework"/>
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
-  <use name="HeterogeneousCore/AlpakaUtilities"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -1,16 +1,19 @@
 <use name="boost_serialization"/>
-<use name="CUDADataFormats/SiPixelCluster"/>
-<use name="CUDADataFormats/SiPixelDigi"/>
-<use name="CalibTracker/SiPixelESProducers"/>
+<use name="DataFormats/SiPixelClusterSoA"/>
+<use name="DataFormats/SiPixelDigiSoA"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="EventFilter/SiPixelRawToDigi"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="HeterogeneousCore/CUDACore"/>
 <use name="RecoTracker/Record"/>
+<use name="CalibTracker/SiPixelESProducers"/>
+
 <iftool name="cuda-gcc-support">
   <use name="cuda"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="CUDADataFormats/SiPixelCluster"/>
+  <use name="CUDADataFormats/SiPixelDigi"/>
   <set name="cuda_src" value="*.cu"/>
 <else/>
   <set name="cuda_src" value=""/>
@@ -18,3 +21,16 @@
 <library file="*.cc ${cuda_src}" name="RecoLocalTrackerSiPixelClusterizerPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>
+<library file="alpaka/*.cc" name="RecoLocalTrackerSiPixelClusterizerPluginsPortable">
+  <use name="alpaka"/>
+  <use name="CalibTracker/Records"/>
+  <use name="HeterogeneousCore/AlpakaTest"/>
+  <use name="DataFormats/Portable"/>
+  <use name="FWCore/Framework"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/AlpakaUtilities"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoAAlpaka.cc
@@ -1,0 +1,211 @@
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigisSoA.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+// local include(s)
+#include "PixelClusterizerBase.h"
+#include "SiPixelClusterThresholds.h"
+
+template <typename TrackerTraits>
+class SiPixelDigisClustersFromSoAAlpaka : public edm::global::EDProducer<> {
+public:
+  explicit SiPixelDigisClustersFromSoAAlpaka(const edm::ParameterSet& iConfig);
+  ~SiPixelDigisClustersFromSoAAlpaka() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
+  edm::EDGetTokenT<SiPixelDigisSoA> digiGetToken_;
+
+  edm::EDPutTokenT<edm::DetSetVector<PixelDigi>> digiPutToken_;
+  edm::EDPutTokenT<SiPixelClusterCollectionNew> clusterPutToken_;
+
+  const SiPixelClusterThresholds clusterThresholds_;  // Cluster threshold in electrons
+
+  const bool produceDigis_;
+  const bool storeDigis_;
+};
+
+template <typename TrackerTraits>
+SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::SiPixelDigisClustersFromSoAAlpaka(const edm::ParameterSet& iConfig)
+    : topoToken_(esConsumes()),
+      digiGetToken_(consumes<SiPixelDigisSoA>(iConfig.getParameter<edm::InputTag>("src"))),
+      clusterPutToken_(produces<SiPixelClusterCollectionNew>()),
+      clusterThresholds_{iConfig.getParameter<int>("clusterThreshold_layer1"),
+                         iConfig.getParameter<int>("clusterThreshold_otherLayers")},
+      produceDigis_(iConfig.getParameter<bool>("produceDigis")),
+      storeDigis_(iConfig.getParameter<bool>("produceDigis") && iConfig.getParameter<bool>("storeDigis")) {
+  if (produceDigis_)
+    digiPutToken_ = produces<edm::DetSetVector<PixelDigi>>();
+}
+
+template <typename TrackerTraits>
+void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("siPixelDigisSoA"));
+  desc.add<int>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
+  desc.add<int>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
+  desc.add<bool>("produceDigis", true);
+  desc.add<bool>("storeDigis", true);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename TrackerTraits>
+void SiPixelDigisClustersFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID,
+                                                               edm::Event& iEvent,
+                                                               const edm::EventSetup& iSetup) const {
+  const auto& digis = iEvent.get(digiGetToken_);
+  const uint32_t nDigis = digis.size();
+  const auto& ttopo = iSetup.getData(topoToken_);
+  constexpr auto maxModules = TrackerTraits::numberOfModules;
+
+  std::unique_ptr<edm::DetSetVector<PixelDigi>> collection;
+  if (produceDigis_)
+    collection = std::make_unique<edm::DetSetVector<PixelDigi>>();
+  if (storeDigis_)
+    collection->reserve(maxModules);
+  auto outputClusters = std::make_unique<SiPixelClusterCollectionNew>();
+  outputClusters->reserve(maxModules, nDigis / 2);
+
+  edm::DetSet<PixelDigi>* detDigis = nullptr;
+  uint32_t detId = 0;
+  for (uint32_t i = 0; i < nDigis; i++) {
+    // check for uninitialized digis
+    // this is set in RawToDigi_kernel in SiPixelRawToClusterGPUKernel.cu
+    if (digis.rawIdArr(i) == 0)
+      continue;
+    // check for noisy/dead pixels (electrons set to 0)
+    if (digis.adc(i) == 0)
+      continue;
+
+    detId = digis.rawIdArr(i);
+    if (storeDigis_) {
+      detDigis = &collection->find_or_insert(detId);
+      if ((*detDigis).empty())
+        (*detDigis).data.reserve(64);  // avoid the first relocations
+    }
+    break;
+  }
+
+  int32_t nclus = -1;
+  PixelClusterizerBase::AccretionCluster aclusters[pixelClustering::maxNumClustersPerModules];
+#ifdef EDM_ML_DEBUG
+  auto totClustersFilled = 0;
+#endif
+
+  auto fillClusters = [&](uint32_t detId) {
+    if (nclus < 0)
+      return;  // this in reality should never happen
+    edmNew::DetSetVector<SiPixelCluster>::FastFiller spc(*outputClusters, detId);
+    auto layer = (DetId(detId).subdetId() == 1) ? ttopo.pxbLayer(detId) : 0;
+    auto clusterThreshold = clusterThresholds_.getThresholdForLayerOnCondition(layer == 1);
+    for (int32_t ic = 0; ic < nclus + 1; ++ic) {
+      auto const& acluster = aclusters[ic];
+      // in any case we cannot  go out of sync with gpu...
+      if (!std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value and acluster.charge < clusterThreshold)
+        edm::LogWarning("SiPixelDigisClustersFromSoA") << "cluster below charge Threshold "
+                                                       << "Layer/DetId/clusId " << layer << '/' << detId << '/' << ic
+                                                       << " size/charge " << acluster.isize << '/' << acluster.charge;
+      // sort by row (x)
+      spc.emplace_back(acluster.isize, acluster.adc, acluster.x, acluster.y, acluster.xmin, acluster.ymin, ic);
+      aclusters[ic].clear();
+#ifdef EDM_ML_DEBUG
+      ++totClustersFilled;
+      const auto& cluster{spc.back()};
+      LogDebug("SiPixelDigisClustersFromSoA")
+          << "putting in this cluster " << ic << " " << cluster.charge() << " " << cluster.pixelADC().size();
+#endif
+      std::push_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+        return cl1.minPixelRow() < cl2.minPixelRow();
+      });
+    }
+    nclus = -1;
+    // sort by row (x)
+    std::sort_heap(spc.begin(), spc.end(), [](SiPixelCluster const& cl1, SiPixelCluster const& cl2) {
+      return cl1.minPixelRow() < cl2.minPixelRow();
+    });
+    if (spc.empty())
+      spc.abort();
+  };
+
+  for (uint32_t i = 0; i < nDigis; i++) {
+    // check for uninitialized digis
+    if (digis.rawIdArr(i) == 0)
+      continue;
+    // check for noisy/dead pixels (electrons set to 0)
+    if (digis.adc(i) == 0)
+      continue;
+    if (digis.clus(i) > 9000)
+      continue;  // not in cluster; TODO add an assert for the size
+#ifdef EDM_ML_DEBUG
+    assert(digis.rawIdArr(i) > 109999);
+#endif
+    if (detId != digis.rawIdArr(i)) {
+      // new module
+      fillClusters(detId);
+#ifdef EDM_ML_DEBUG
+      assert(nclus == -1);
+#endif
+      detId = digis.rawIdArr(i);
+      if (storeDigis_) {
+        detDigis = &collection->find_or_insert(detId);
+        if ((*detDigis).empty())
+          (*detDigis).data.reserve(64);  // avoid the first relocations
+        else {
+          edm::LogWarning("SiPixelDigisClustersFromSoA")
+              << "Problem det present twice in input! " << (*detDigis).detId();
+        }
+      }
+    }
+    PixelDigi dig(digis.pdigi(i));
+    if (storeDigis_)
+      (*detDigis).data.emplace_back(dig);
+      // fill clusters
+#ifdef EDM_ML_DEBUG
+    assert(digis.clus(i) >= 0);
+    assert(digis.clus(i) < pixelClustering::maxNumClustersPerModules);
+#endif
+    nclus = std::max(digis.clus(i), nclus);
+    auto row = dig.row();
+    auto col = dig.column();
+    SiPixelCluster::PixelPos pix(row, col);
+    aclusters[digis.clus(i)].add(pix, digis.adc(i));
+  }
+
+  // fill final clusters
+  if (detId > 0)
+    fillClusters(detId);
+
+#ifdef EDM_ML_DEBUG
+  LogDebug("SiPixelDigisClustersFromSoA") << "filled " << totClustersFilled << " clusters";
+#endif
+
+  if (produceDigis_)
+    iEvent.put(digiPutToken_, std::move(collection));
+  iEvent.put(clusterPutToken_, std::move(outputClusters));
+}
+
+using SiPixelDigisClustersFromSoAAlpakaPhase1 = SiPixelDigisClustersFromSoAAlpaka<pixelTopology::Phase1>;
+DEFINE_FWK_MODULE(SiPixelDigisClustersFromSoAAlpakaPhase1);
+using SiPixelDigisClustersFromSoAAlpakaPhase2 = SiPixelDigisClustersFromSoAAlpaka<pixelTopology::Phase2>;
+DEFINE_FWK_MODULE(SiPixelDigisClustersFromSoAAlpakaPhase2);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
@@ -1,0 +1,138 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_alpaka_CalibPixel_h
+#define RecoLocalTracker_SiPixelClusterizer_alpaka_CalibPixel_h
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+#include <alpaka/alpaka.hpp>
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTUtilities.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisErrorLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace calibPixel {
+    using namespace cms::alpakatools;
+    constexpr uint16_t InvId = std::numeric_limits<uint16_t>::max();
+    ;  // must be > MaxNumModules
+
+    // valid for run2
+    constexpr float VCaltoElectronGain = 47;         // L2-4: 47 +- 4.7
+    constexpr float VCaltoElectronGain_L1 = 50;      // L1:   49.6 +- 2.6
+    constexpr float VCaltoElectronOffset = -60;      // L2-4: -60 +- 130
+    constexpr float VCaltoElectronOffset_L1 = -670;  // L1:   -670 +- 220
+
+    //for phase2
+    constexpr float ElectronPerADCGain = 1500;
+    constexpr int8_t Phase2ReadoutMode = 3;
+    constexpr uint16_t Phase2DigiBaseline = 1000;
+    constexpr uint8_t Phase2KinkADC = 8;
+
+    struct calibDigis {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    bool isRun2,
+                                    SiPixelDigisLayoutSoAView& view,
+                                    SiPixelClustersLayoutSoAView& clus_view,
+                                    const SiPixelGainCalibrationForHLTSoAConstView& gains,
+                                    int numElements) const {
+        const uint32_t threadIdxGlobal(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+
+        // zero for next kernels...
+        if (threadIdxGlobal == 0) {
+          clus_view[0].clusModuleStart() = clus_view[0].moduleStart();
+        }
+
+        // cms::alpakatools::for_each_element_in_grid_strided(
+        //     acc, phase1PixelTopology::numberOfModules, [&](uint32_t i) { clus_view[i].clusInModule() = 0; });
+
+        // cms::alpakatools::for_each_element_in_grid_strided(acc, numElements, [&](uint32_t i) {
+        //   auto dvgi = view[i];
+        //   if (dvgi.moduleId() != InvId) {
+        //     float conversionFactor =
+        //         (isRun2) ? (dvgi.moduleId() < 96 ? VCaltoElectronGain_L1 : VCaltoElectronGain) : 1.f;
+        //     float offset = (isRun2) ? (dvgi.moduleId() < 96 ? VCaltoElectronOffset_L1 : VCaltoElectronOffset) : 0;
+
+        //     bool isDeadColumn = false, isNoisyColumn = false;
+
+        //     int row = dvgi.xx();
+        //     int col = dvgi.yy();
+
+        //     auto ret =
+        //         SiPixelGainUtilities::getPedAndGain(gains, dvgi.moduleId(), col, row, isDeadColumn, isNoisyColumn);
+
+        //     float pedestal = ret.first;
+        //     float gain = ret.second;
+        //     // float pedestal = 0; float gain = 1.;
+        //     if (isDeadColumn | isNoisyColumn) {
+        //       dvgi.moduleId() = InvId;
+        //       dvgi.adc() = 0;
+        //       printf("bad pixel at %d in %d\n", i, dvgi.moduleId());
+        //     } else {
+        //       float vcal = dvgi.adc() * gain - pedestal * gain;
+        //       dvgi.adc() = std::max(100, int(vcal * conversionFactor + offset));
+        //     }
+        //   }
+        // });
+      }
+    };
+
+    // struct calibDigisPhase2 {
+    //   template <typename TAcc>
+    //   ALPAKA_FN_ACC void operator()(const TAcc& acc,
+    //                                 SiPixelDigisLayoutSoAView& view,
+    //                                 SiPixelClustersLayoutSoAView& clus_view,
+    //                                 int numElements
+    //   ) const {
+    //     const uint32_t threadIdxGlobal(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+    //     // zero for next kernels...
+
+    //     if (0 == threadIdxGlobal)
+    //       clus_view[0].clusModuleStart() = clus_view[0].moduleStart();
+    //     cms::alpakatools::for_each_element_in_grid_strided(
+    //         acc, phase2PixelTopology::numberOfModules, [&](uint32_t i) { clus_view[i].clusInModule() = 0; });
+
+    //     cms::alpakatools::for_each_element_in_grid_strided(acc, numElements, [&](uint32_t i) {
+    //       auto dvgi = view[i];
+    //       if (pixelClustering::invalidModuleId != dvgi.moduleId()) {
+    //         constexpr int mode = (Phase2ReadoutMode < -1 ? -1 : Phase2ReadoutMode);
+
+    //         int adc_int = dvgi.adc();
+
+    //         if constexpr (mode < 0)
+    //           adc_int = int(adc_int * ElectronPerADCGain);
+    //         else {
+    //           if (adc_int < Phase2KinkADC)
+    //             adc_int = int((adc_int + 0.5) * ElectronPerADCGain);
+    //           else {
+    //             constexpr int8_t dspp = (Phase2ReadoutMode < 10 ? Phase2ReadoutMode : 10);
+    //             constexpr int8_t ds = int8_t(dspp <= 1 ? 1 : (dspp - 1) * (dspp - 1));
+
+    //             adc_int -= Phase2KinkADC;
+    //             adc_int *= ds;
+    //             adc_int += Phase2KinkADC;
+
+    //             adc_int = ((adc_int + 0.5 * ds) * ElectronPerADCGain);
+    //           }
+
+    //           adc_int += int(Phase2DigiBaseline);
+    //         }
+    //         dvgi.adc() = std::min(adc_int, int(std::numeric_limits<uint16_t>::max()));
+    //       }
+    //     });
+    //   }
+    // };
+
+  }  // namespace calibPixel
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelClusterizer_alpaka_CalibPixel.h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -1,0 +1,154 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_alpaka_ClusterChargeCut_h
+#define RecoLocalTracker_SiPixelClusterizer_alpaka_ClusterChargeCut_h
+
+#include <cstdint>
+#include <cstdio>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+
+// namespace ALPAKA_ACCELERATOR_NAMESPACE {
+namespace pixelClustering {
+
+  template <typename TrackerTraits>
+  struct clusterChargeCut {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(
+        const TAcc& acc,
+        SiPixelDigisLayoutSoAView digi_view,
+        SiPixelClustersLayoutSoAView clus_view,
+        SiPixelClusterThresholds
+            clusterThresholds,  // charge cut on cluster in electrons (for layer 1 and for other layers)
+        const uint32_t numElements) const {
+      constexpr int startBPIX2 = TrackerTraits::layerStart[1];
+      [[maybe_unused]] constexpr int nMaxModules = TrackerTraits::numberOfModules;
+
+      const uint32_t blockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      if (blockIdx >= clus_view[0].moduleStart())
+        return;
+
+      auto firstPixel = clus_view[1 + blockIdx].moduleStart();
+      auto thisModuleId = digi_view[firstPixel].moduleId();
+
+      ALPAKA_ASSERT_OFFLOAD(nMaxModules < maxNumModules);
+      ALPAKA_ASSERT_OFFLOAD(startBPIX2 < nMaxModules);
+
+      auto nclus = clus_view[thisModuleId].clusInModule();
+      if (nclus == 0)
+        return;
+
+      const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+      if (threadIdxLocal == 0 && nclus > maxNumClustersPerModules)
+        printf("Warning too many clusters in module %d in block %d: %d > %d\n",
+               thisModuleId,
+               blockIdx,
+               nclus,
+               maxNumClustersPerModules);
+
+      // Stride = block size.
+      const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+
+      // Get thread / CPU element indices in block.
+      const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+          cms::alpakatools::element_index_range_in_block(acc, firstPixel);
+
+      if (nclus > maxNumClustersPerModules) {
+        uint32_t firstElementIdx = firstElementIdxNoStride;
+        uint32_t endElementIdx = endElementIdxNoStride;
+        // remove excess  FIXME find a way to cut charge first....
+        for (uint32_t i = firstElementIdx; i < numElements; ++i) {
+          if (not cms::alpakatools::next_valid_element_index_strided(
+                  i, firstElementIdx, endElementIdx, blockDimension, numElements))
+            break;
+          if (digi_view[i].moduleId() == invalidModuleId)
+            continue;  // not valid
+          if (digi_view[i].moduleId() != thisModuleId)
+            break;  // end of module
+          if (digi_view[i].clus() >= maxNumClustersPerModules) {
+            digi_view[i].moduleId() = invalidModuleId;
+            digi_view[i].clus() = invalidModuleId;
+          }
+        }
+        nclus = maxNumClustersPerModules;
+      }
+
+#ifdef GPU_DEBUG
+      if (thisModuleId % 100 == 1)
+        if (threadIdxLocal == 0)
+          printf("start clusterizer for module %d in block %d\n", thisModuleId, blockIdx);
+#endif
+
+      auto& charge = alpaka::declareSharedVar<int32_t[maxNumClustersPerModules], __COUNTER__>(acc);
+      auto& ok = alpaka::declareSharedVar<uint8_t[maxNumClustersPerModules], __COUNTER__>(acc);
+      auto& newclusId = alpaka::declareSharedVar<uint16_t[maxNumClustersPerModules], __COUNTER__>(acc);
+
+      ALPAKA_ASSERT_OFFLOAD(nclus <= maxNumClustersPerModules);
+      cms::alpakatools::for_each_element_in_block_strided(acc, nclus, [&](uint32_t i) { charge[i] = 0; });
+      alpaka::syncBlockThreads(acc);
+
+      uint32_t firstElementIdx = firstElementIdxNoStride;
+      uint32_t endElementIdx = endElementIdxNoStride;
+      for (uint32_t i = firstElementIdx; i < numElements; ++i) {
+        if (not cms::alpakatools::next_valid_element_index_strided(
+                i, firstElementIdx, endElementIdx, blockDimension, numElements))
+          break;
+        if (digi_view[i].moduleId() == invalidModuleId)
+          continue;  // not valid
+        if (digi_view[i].moduleId() != thisModuleId)
+          break;  // end of module
+        alpaka::atomicAdd(
+            acc, &charge[digi_view[i].clus()], static_cast<int32_t>(digi_view[i].adc()), alpaka::hierarchy::Threads{});
+      }
+      alpaka::syncBlockThreads(acc);
+
+      auto chargeCut = clusterThresholds.getThresholdForLayerOnCondition(thisModuleId < startBPIX2);
+      cms::alpakatools::for_each_element_in_block_strided(
+          acc, nclus, [&](uint32_t i) { newclusId[i] = ok[i] = charge[i] > chargeCut ? 1 : 0; });
+      alpaka::syncBlockThreads(acc);
+
+      // renumber
+      auto& ws = alpaka::declareSharedVar<uint16_t[32], __COUNTER__>(acc);
+      cms::alpakatools::blockPrefixScan(acc, newclusId, nclus, ws);
+
+      ALPAKA_ASSERT_OFFLOAD(nclus >= newclusId[nclus - 1]);
+
+      if (nclus == newclusId[nclus - 1])
+        return;
+
+      clus_view[thisModuleId].clusInModule() = newclusId[nclus - 1];
+      alpaka::syncBlockThreads(acc);
+
+      // mark bad cluster again
+      cms::alpakatools::for_each_element_in_block_strided(acc, nclus, [&](uint32_t i) {
+        if (0 == ok[i])
+          newclusId[i] = invalidModuleId + 1;
+      });
+      alpaka::syncBlockThreads(acc);
+
+      // reassign id
+      firstElementIdx = firstElementIdxNoStride;
+      endElementIdx = endElementIdxNoStride;
+      for (uint32_t i = firstElementIdx; i < numElements; ++i) {
+        if (not cms::alpakatools::next_valid_element_index_strided(
+                i, firstElementIdx, endElementIdx, blockDimension, numElements))
+          break;
+        if (digi_view[i].moduleId() == invalidModuleId)
+          continue;  // not valid
+        if (digi_view[i].moduleId() != thisModuleId)
+          break;  // end of module
+        digi_view[i].clus() = newclusId[digi_view[i].clus()] - 1;
+        if (digi_view[i].clus() == invalidModuleId)
+          digi_view[i].moduleId() = invalidModuleId;
+      }
+
+      //done
+    }
+  };
+
+}  // namespace pixelClustering
+
+#endif  //

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -5,7 +5,7 @@
 #include <cstdio>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersLayout.h"

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -1,0 +1,459 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_alpaka_PixelClustering_h
+#define RecoLocalTracker_SiPixelClusterizer_alpaka_PixelClustering_h
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+
+// #include "pixelClusteringUtilities.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace pixelClustering {
+
+#ifdef GPU_DEBUG
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_STATIC_ACC_MEM_GLOBAL uint32_t gMaxHit = 0;
+#endif
+
+    struct PixelStatus {
+      // Phase-1 pixel modules
+      static constexpr uint32_t pixelSizeX = pixelTopology::Phase1::numRowsInModule;
+      static constexpr uint32_t pixelSizeY = pixelTopology::Phase1::numColsInModule;
+
+      // Use 0x00, 0x01, 0x03 so each can be OR'ed on top of the previous ones
+      enum Status : uint32_t { kEmpty = 0x00, kFound = 0x01, kDuplicate = 0x03 };
+
+      static constexpr uint32_t bits = 2;
+      static constexpr uint32_t mask = (0x01 << bits) - 1;
+      static constexpr uint32_t valuesPerWord = sizeof(uint32_t) * 8 / bits;
+      static constexpr uint32_t size = pixelSizeX * pixelSizeY / valuesPerWord;
+
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr static uint32_t getIndex(uint16_t x, uint16_t y) {
+        return (pixelSizeX * y + x) / valuesPerWord;
+      }
+
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr static uint32_t getShift(uint16_t x, uint16_t y) {
+        return (x % valuesPerWord) * 2;
+      }
+
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr static Status getStatus(uint32_t const* __restrict__ status,
+                                                                       uint16_t x,
+                                                                       uint16_t y) {
+        uint32_t index = getIndex(x, y);
+        uint32_t shift = getShift(x, y);
+        return Status{(status[index] >> shift) & mask};
+      }
+
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr static bool isDuplicate(uint32_t const* __restrict__ status,
+                                                                       uint16_t x,
+                                                                       uint16_t y) {
+        return getStatus(status, x, y) == kDuplicate;
+      }
+
+      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC ALPAKA_FN_INLINE constexpr static void promote(TAcc const& acc,
+                                                                   uint32_t* __restrict__ status,
+                                                                   const uint16_t x,
+                                                                   const uint16_t y) {
+        uint32_t index = getIndex(x, y);
+        uint32_t shift = getShift(x, y);
+        uint32_t old_word = status[index];
+        uint32_t expected = old_word;
+        do {
+          expected = old_word;
+          Status old_status{(old_word >> shift) & mask};
+          if (kDuplicate == old_status) {
+            // nothing to do
+            return;
+          }
+          Status new_status = (kEmpty == old_status) ? kFound : kDuplicate;
+          uint32_t new_word = old_word | (static_cast<uint32_t>(new_status) << shift);
+          old_word = alpaka::atomicCas(acc, &status[index], expected, new_word, alpaka::hierarchy::Blocks{});
+        } while (expected != old_word);
+      }
+
+    };  // struct PixelStatus
+
+    template <typename TrackerTraits>
+    struct countModules {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    SiPixelDigisLayoutSoAView digi_view,
+                                    SiPixelClustersLayoutSoAView clus_view,
+                                    const unsigned int numElements) const {
+        [[maybe_unused]] constexpr int nMaxModules = TrackerTraits::numberOfModules;
+        assert(nMaxModules < nMaxModules);  //TODO better naming
+
+        cms::alpakatools::for_each_element_in_grid_strided(acc, numElements, [&](uint32_t i) {
+          digi_view[i].clus() = i;
+          if (::pixelClustering::invalidModuleId != digi_view[i].moduleId()) {
+            int j = i - 1;
+            while (j >= 0 and digi_view[j].moduleId() == ::pixelClustering::invalidModuleId)
+              --j;
+            if (j < 0 or digi_view[j].moduleId() != digi_view[i].moduleId()) {
+              // boundary...
+              auto loc = alpaka::atomicInc(
+                  acc, clus_view.moduleStart(), std::decay_t<uint32_t>(nMaxModules), alpaka::hierarchy::Blocks{});
+
+              clus_view[loc + 1].moduleStart() = i;
+            }
+          }
+        });
+      }
+    };
+
+    template <typename TrackerTraits>
+    struct findClus {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    SiPixelDigisLayoutSoAView digi_view,
+                                    SiPixelClustersLayoutSoAView clus_view,
+                                    const unsigned int numElements) const {
+        const uint32_t blockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+        if (blockIdx >= clus_view[0].moduleStart())
+          return;
+
+        auto firstPixel = clus_view[1 + blockIdx].moduleStart();
+        auto thisModuleId = digi_view[firstPixel].moduleId();
+        ALPAKA_ASSERT_OFFLOAD(thisModuleId < TrackerTraits::numberOfModules);
+
+        const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+
+#ifdef GPU_DEBUG
+        if (thisModuleId % 100 == 1)
+          if (threadIdxLocal == 0)
+            printf("start clusterizer for module %d in block %d\n", thisModuleId, blockIdx);
+#endif
+
+        constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
+        constexpr const uint32_t pixelStatusSize = isPhase2 ? 1 : PixelStatus::size;
+
+        auto&& status = alpaka::declareSharedVar<uint32_t[pixelStatusSize], __COUNTER__>(
+            acc);  // packed words array used to store the PixelStatus of each pixel
+
+        // find the index of the first pixel not belonging to this module (or invalid)
+        auto& msize = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+        msize = numElements;
+        alpaka::syncBlockThreads(acc);
+
+        // Stride = block size.
+        const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+
+        // Get thread / CPU element indices in block.
+        const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+            cms::alpakatools::element_index_range_in_block(acc, firstPixel);
+        uint32_t firstElementIdx = firstElementIdxNoStride;
+        uint32_t endElementIdx = endElementIdxNoStride;
+
+        // skip threads not associated to an existing pixel
+        for (uint32_t i = firstElementIdx; i < numElements; ++i) {
+          if (not cms::alpakatools::next_valid_element_index_strided(
+                  i, firstElementIdx, endElementIdx, blockDimension, numElements))
+            break;
+          auto id = digi_view[i].moduleId();
+          if (id == ::pixelClustering::invalidModuleId)  // skip invalid pixels
+            continue;
+          if (id != thisModuleId) {  // find the first pixel in a different module
+            alpaka::atomicMin(acc, &msize, i, alpaka::hierarchy::Threads{});
+            break;
+          }
+        }
+
+        //init hist  (ymax=416 < 512 : 9bits)
+        constexpr uint32_t maxPixInModule = TrackerTraits::maxPixInModule;
+        constexpr auto nbins = TrackerTraits::clusterBinning;
+        constexpr auto nbits = TrackerTraits::clusterBits;
+
+        using Hist = cms::alpakatools::HistoContainer<uint16_t, nbins, maxPixInModule, nbits, uint16_t>;
+        auto& hist = alpaka::declareSharedVar<Hist, __COUNTER__>(acc);
+        auto& ws = alpaka::declareSharedVar<typename Hist::Counter[32], __COUNTER__>(acc);
+
+        cms::alpakatools::for_each_element_in_block_strided(acc, Hist::totbins(), [&](uint32_t j) { hist.off[j] = 0; });
+        alpaka::syncBlockThreads(acc);
+
+        ALPAKA_ASSERT_OFFLOAD((msize == numElements) or
+                              ((msize < numElements) and (digi_view[msize].moduleId() != thisModuleId)));
+
+        // limit to maxPixInModule  (FIXME if recurrent (and not limited to simulation with low threshold) one will need to implement something cleverer)
+        if (0 == threadIdxLocal) {
+          if (msize - firstPixel > maxPixInModule) {
+            printf("too many pixels in module %d: %d > %d\n", thisModuleId, msize - firstPixel, maxPixInModule);
+            msize = maxPixInModule + firstPixel;
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);
+        ALPAKA_ASSERT_OFFLOAD(msize - firstPixel <= maxPixInModule);
+
+#ifdef GPU_DEBUG
+        auto& totGood = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
+        totGood = 0;
+        alpaka::syncBlockThreads(acc);
+#endif
+
+        // remove duplicate pixels
+        if constexpr (not isPhase2) {
+          if (msize > 1) {
+            cms::alpakatools::for_each_element_in_block_strided(
+                acc, PixelStatus::size, [&](uint32_t i) { status[i] = 0; });
+            alpaka::syncBlockThreads(acc);
+
+            // for (uint32_t i = firstElementIdx; i < msize - 1; ++i) {
+            cms::alpakatools::for_each_element_in_block_strided(acc, msize - 1, firstElementIdx, [&](uint32_t i) {
+              // skip invalid pixels
+              if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+                return;
+              PixelStatus::promote(acc, status, digi_view[i].xx(), digi_view[i].yy());
+            });
+            alpaka::syncBlockThreads(acc);
+            // for (uint32_t i = firstElementIdx; i < msize - 1; ++i) {
+            cms::alpakatools::for_each_element_in_block_strided(acc, msize - 1, firstElementIdx, [&](uint32_t i) {
+              // skip invalid pixels
+              if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId)
+                return;
+              if (PixelStatus::isDuplicate(status, digi_view[i].xx(), digi_view[i].yy())) {
+                // printf("found dup %d %d %d %d\n", i, digi_view[i].moduleId(), digi_view[i].xx(), digi_view[i].yy());
+                digi_view[i].moduleId() = ::pixelClustering::invalidModuleId;
+                digi_view[i].rawIdArr() = 0;
+              }
+            });
+            alpaka::syncBlockThreads(acc);
+          }
+        }
+
+        // fill histo
+        cms::alpakatools::for_each_element_in_block_strided(acc, msize, firstPixel, [&](uint32_t i) {
+          if (digi_view[i].moduleId() != ::pixelClustering::invalidModuleId) {  // skip invalid pixels
+            hist.count(acc, digi_view[i].yy());
+#ifdef GPU_DEBUG
+            alpaka::atomicAdd(acc, &totGood, 1u, alpaka::hierarchy::Blocks{});
+#endif
+          }
+        });
+        alpaka::syncBlockThreads(acc);
+        cms::alpakatools::for_each_element_in_block(acc, 32u, [&](uint32_t i) {
+          ws[i] = 0;  // used by prefix scan...
+        });
+        alpaka::syncBlockThreads(acc);
+        hist.finalize(acc, ws);
+        alpaka::syncBlockThreads(acc);
+#ifdef GPU_DEBUG
+        ALPAKA_ASSERT_OFFLOAD(hist.size() == totGood);
+        if (thisModuleId % 100 == 1)
+          if (threadIdxLocal == 0)
+            printf("histo size %d\n", hist.size());
+#endif
+        cms::alpakatools::for_each_element_in_block_strided(acc, msize, firstPixel, [&](uint32_t i) {
+          if (digi_view[i].moduleId() != ::pixelClustering::invalidModuleId) {  // skip invalid pixels
+            hist.fill(acc, digi_view[i].yy(), i - firstPixel);
+          }
+        });
+
+        // Assume that we can cover the whole module with up to 16 blockDimension-wide iterations
+        // This maxiter value was tuned for GPU, with 256 or 512 threads per block.
+        // Hence, also works for CPU case, with 256 or 512 elements per thread.
+        // Real constrainst is maxiter = hist.size() / blockDimension,
+        // with blockDimension = threadPerBlock * elementsPerThread.
+        // Hence, maxiter can be tuned accordingly to the workdiv.
+        constexpr unsigned int maxiter = 16;
+        ALPAKA_ASSERT_OFFLOAD((hist.size() / blockDimension) <= maxiter);
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND) || defined(ALPAKA_ACC_GPU_HIP_ASYNC_BACKEND)
+        constexpr uint32_t threadDimension = 1;
+#else
+        // NB: can be tuned.
+        constexpr uint32_t threadDimension = 256;
+#endif
+
+#ifndef NDEBUG
+        [[maybe_unused]] const uint32_t runTimeThreadDimension(
+            alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+        ALPAKA_ASSERT_OFFLOAD(runTimeThreadDimension <= threadDimension);
+#endif
+
+        // nearest neighbour
+        // allocate space for duplicate pixels: a pixel can appear more than once with different charge in the same event
+        constexpr int maxNeighbours = 10;
+        uint16_t nn[maxiter][threadDimension][maxNeighbours];
+        uint8_t nnn[maxiter][threadDimension];  // number of nn
+        for (uint32_t elementIdx = 0; elementIdx < threadDimension; ++elementIdx) {
+          for (uint32_t k = 0; k < maxiter; ++k) {
+            nnn[k][elementIdx] = 0;
+          }
+        }
+
+        alpaka::syncBlockThreads(acc);  // for hit filling!
+
+#ifdef GPU_DEBUG
+        // look for anomalous high occupancy
+        auto& n40 = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
+        auto& n60 = alpaka::declareSharedVar<uint32_t, __COUNTER__>(acc);
+        n40 = n60 = 0;
+        alpaka::syncBlockThreads(acc);
+        cms::alpakatools::for_each_element_in_block_strided(acc, Hist::nbins(), [&](uint32_t j) {
+          if (hist.size(j) > 60)
+            alpaka::atomicAdd(acc, &n60, 1u, alpaka::hierarchy::Blocks{});
+          if (hist.size(j) > 40)
+            alpaka::atomicAdd(acc, &n40, 1u, alpaka::hierarchy::Blocks{});
+        });
+        alpaka::syncBlockThreads(acc);
+        if (0 == threadIdxLocal) {
+          if (n60 > 0)
+            printf("columns with more than 60 px %d in %d\n", n60, thisModuleId);
+          else if (n40 > 0)
+            printf("columns with more than 40 px %d in %d\n", n40, thisModuleId);
+        }
+        alpaka::syncBlockThreads(acc);
+#endif
+
+        // fill NN
+        uint32_t k = 0u;
+        cms::alpakatools::for_each_element_in_block_strided(acc, hist.size(), [&](uint32_t j) {
+          const uint32_t jEquivalentClass = j % threadDimension;
+          k = j / blockDimension;
+          ALPAKA_ASSERT_OFFLOAD(k < maxiter);
+          auto p = hist.begin() + j;
+          auto i = *p + firstPixel;
+          ALPAKA_ASSERT_OFFLOAD(digi_view[i].moduleId() != ::pixelClustering::invalidModuleId);
+          ALPAKA_ASSERT_OFFLOAD(digi_view[i].moduleId() == thisModuleId);  // same module
+          int be = Hist::bin(digi_view[i].yy() + 1);
+          auto e = hist.end(be);
+          ++p;
+          ALPAKA_ASSERT_OFFLOAD(0 == nnn[k][jEquivalentClass]);
+          for (; p < e; ++p) {
+            auto m = (*p) + firstPixel;
+            ALPAKA_ASSERT_OFFLOAD(m != i);
+            ALPAKA_ASSERT_OFFLOAD(int(digi_view[m].yy()) - int(digi_view[i].yy()) >= 0);
+            ALPAKA_ASSERT_OFFLOAD(int(digi_view[m].yy()) - int(digi_view[i].yy()) <= 1);
+            if (std::abs(int(digi_view[m].xx()) - int(digi_view[i].xx())) <= 1) {
+              auto l = nnn[k][jEquivalentClass]++;
+              ALPAKA_ASSERT_OFFLOAD(l < maxNeighbours);
+              nn[k][jEquivalentClass][l] = *p;
+            }
+          }
+        });
+
+        // for each pixel, look at all the pixels until the end of the module;
+        // when two valid pixels within +/- 1 in x or y are found, set their id to the minimum;
+        // after the loop, all the pixel in each cluster should have the id equeal to the lowest
+        // pixel in the cluster ( clus[i] == i ).
+        bool more = true;
+        int nloops = 0;
+        while (alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, more)) {
+          if (1 == nloops % 2) {
+            cms::alpakatools::for_each_element_in_block_strided(acc, hist.size(), [&](uint32_t j) {
+              auto p = hist.begin() + j;
+              auto i = *p + firstPixel;
+              auto m = digi_view[i].clus();
+              while (m != digi_view[m].clus())
+                m = digi_view[m].clus();
+              digi_view[i].clus() = m;
+            });
+          } else {
+            more = false;
+            uint32_t k = 0u;
+            cms::alpakatools::for_each_element_in_block_strided(acc, hist.size(), [&](uint32_t j) {
+              k = j / blockDimension;
+              const uint32_t jEquivalentClass = j % threadDimension;
+              auto p = hist.begin() + j;
+              auto i = *p + firstPixel;
+              for (int kk = 0; kk < nnn[k][jEquivalentClass]; ++kk) {
+                auto l = nn[k][jEquivalentClass][kk];
+                auto m = l + firstPixel;
+                ALPAKA_ASSERT_OFFLOAD(m != i);
+                auto old =
+                    alpaka::atomicMin(acc, &digi_view[m].clus(), digi_view[i].clus(), alpaka::hierarchy::Blocks{});
+                if (old != digi_view[i].clus()) {
+                  // end the loop only if no changes were applied
+                  more = true;
+                }
+                alpaka::atomicMin(acc, &digi_view[i].clus(), old, alpaka::hierarchy::Blocks{});
+              }  // nnloop
+            });  // pixel loop
+          }
+          ++nloops;
+        }  // end while
+
+#ifdef GPU_DEBUG
+        {
+          auto& n0 = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+          if (threadIdxLocal == 0)
+            n0 = nloops;
+          alpaka::syncBlockThreads(acc);
+#ifndef NDEBUG
+          [[maybe_unused]] auto ok = n0 == nloops;
+          ALPAKA_ASSERT_OFFLOAD(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, ok));
+#endif
+          if (thisModuleId % 100 == 1)
+            if (threadIdxLocal == 0)
+              printf("# loops %d\n", nloops);
+        }
+#endif
+
+        auto& foundClusters = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+        foundClusters = 0;
+        alpaka::syncBlockThreads(acc);
+
+        // find the number of different clusters, identified by a pixels with clus[i] == i;
+        // mark these pixels with a negative id.
+        cms::alpakatools::for_each_element_in_block_strided(acc, msize, firstPixel, [&](uint32_t i) {
+          if (digi_view[i].moduleId() != ::pixelClustering::invalidModuleId) {  // skip invalid pixels
+            if (digi_view[i].clus() == static_cast<int>(i)) {
+              auto old = alpaka::atomicInc(acc, &foundClusters, 0xffffffff, alpaka::hierarchy::Threads{});
+              digi_view[i].clus() = -(old + 1);
+            }
+          }
+        });
+        alpaka::syncBlockThreads(acc);
+
+        // propagate the negative id to all the pixels in the cluster.
+        cms::alpakatools::for_each_element_in_block_strided(acc, msize, firstPixel, [&](uint32_t i) {
+          if (digi_view[i].moduleId() != ::pixelClustering::invalidModuleId) {  // skip invalid pixels
+            if (digi_view[i].clus() >= 0) {
+              // mark each pixel in a cluster with the same id as the first one
+              digi_view[i].clus() = digi_view[digi_view[i].clus()].clus();
+            }
+          }
+        });
+        alpaka::syncBlockThreads(acc);
+
+        // adjust the cluster id to be a positive value starting from 0
+        cms::alpakatools::for_each_element_in_block_strided(acc, msize, firstPixel, [&](uint32_t i) {
+          if (digi_view[i].moduleId() == ::pixelClustering::invalidModuleId) {  // skip invalid pixels
+            digi_view[i].clus() = -9999;
+          } else {
+            digi_view[i].clus() = -digi_view[i].clus() - 1;
+          }
+        });
+        alpaka::syncBlockThreads(acc);
+
+        if (threadIdxLocal == 0) {
+          clus_view[thisModuleId].clusInModule() = foundClusters;
+          clus_view[blockIdx].moduleId() = thisModuleId;
+#ifdef GPU_DEBUG
+          if (foundClusters > gMaxHit<TAcc>) {
+            gMaxHit<TAcc> = foundClusters;
+            if (foundClusters > 8)
+              printf("max hit %d in %d\n", foundClusters, thisModuleId);
+          }
+#endif
+#ifdef GPU_DEBUG
+          if (thisModuleId % 100 == 1)
+            printf("%d clusters in module %d\n", foundClusters, thisModuleId);
+#endif
+        }
+      }
+    };
+
+  }  // namespace pixelClustering
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+#endif  // plugin_SiPixelClusterizer_alpaka_PixelClustering.h

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -8,10 +8,10 @@
 #include <alpaka/alpaka.hpp>
 
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 
 // #include "pixelClusteringUtilities.h"
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -1,0 +1,170 @@
+// C++ includes
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaCore/interface/ScopedContext.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+// #include "SiPixelRawToClusterKernel.h"
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
+#include "SiPixelRawToClusterKernel.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class SiPixelPhase2DigiToCluster : public stream::SynchronizingEDProducer<> {
+  public:
+    explicit SiPixelPhase2DigiToCluster(const edm::ParameterSet& iConfig);
+    ~SiPixelPhase2DigiToCluster() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override;
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override;
+
+    // cms::alpakatools::ContextState<Queue> ctxState_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+    const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
+
+    device::EDPutToken<SiPixelDigisDevice> digiPutToken_;
+    device::EDPutToken<SiPixelDigiErrorsDevice> digiErrorPutToken_;
+    device::EDPutToken<SiPixelClustersDevice> clusterPutToken_;
+
+    pixelDetails::SiPixelRawToClusterKernel Algo_;
+
+    const bool includeErrors_;
+    const SiPixelClusterThresholds clusterThresholds_;
+    uint32_t nDigis_ = 0;
+
+    SiPixelDigisDevice digis_d;
+  };
+
+  SiPixelPhase2DigiToCluster::SiPixelPhase2DigiToCluster(const edm::ParameterSet& iConfig)
+      : geomToken_(esConsumes()),
+        pixelDigiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("InputDigis"))),
+        digiPutToken_(produces()),
+        clusterPutToken_(produces()),
+        includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),
+        clusterThresholds_{iConfig.getParameter<int32_t>("clusterThreshold_layer1"),
+                           iConfig.getParameter<int32_t>("clusterThreshold_otherLayers")} {
+    if (includeErrors_) {
+      digiErrorPutToken_ = produces();
+    }
+  }
+
+  void SiPixelPhase2DigiToCluster::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    desc.add<bool>("IncludeErrors", true);
+    desc.add<int32_t>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase2.layer1);
+    desc.add<int32_t>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase2.otherLayers);
+    desc.add<edm::InputTag>("InputDigis", edm::InputTag("simSiPixelDigis:Pixel"));
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void SiPixelPhase2DigiToCluster::acquire(device::Event const& iEvent, device::EventSetup const& iSetup) {
+    // cms::cuda::ScopedContextAcquire ctx{iEvent.streamID(), std::move(waitingTaskHolder), ctxState_};
+
+    auto const& input = iEvent.get(pixelDigiToken_);
+
+    const TrackerGeometry* geom_ = &iSetup.getData(geomToken_);
+
+    uint32_t nDigis = 0;
+    for (auto DSViter = input.begin(); DSViter != input.end(); DSViter++) {
+      nDigis = nDigis + DSViter->size();
+    }
+    SiPixelDigisHost digis_h(nDigis, iEvent.queue());
+    nDigis_ = nDigis;
+
+    if (nDigis_ == 0)
+      return;
+
+    nDigis = 0;
+    for (auto DSViter = input.begin(); DSViter != input.end(); DSViter++) {
+      unsigned int detid = DSViter->detId();
+      DetId detIdObject(detid);
+      const GeomDetUnit* genericDet = geom_->idToDetUnit(detIdObject);
+      auto const gind = genericDet->index();
+      for (auto const& px : *DSViter) {
+        digis_h.view()[nDigis].moduleId() = uint16_t(gind);
+
+        digis_h.view()[nDigis].xx() = uint16_t(px.row());
+        digis_h.view()[nDigis].yy() = uint16_t(px.column());
+        digis_h.view()[nDigis].adc() = uint16_t(px.adc());
+
+        digis_h.view()[nDigis].pdigi() = uint32_t(px.packedData());
+
+        digis_h.view()[nDigis].rawIdArr() = uint32_t(detid);
+
+        nDigis++;
+      }
+    }
+
+    digis_d = SiPixelDigisDevice(nDigis, iEvent.queue());
+    alpaka::memcpy(iEvent.queue(), digis_d.buffer(), digis_h.buffer());
+
+    Algo_.makePhase2ClustersAsync(clusterThresholds_, digis_d.view(), nDigis, iEvent.queue());
+  }
+
+  void SiPixelPhase2DigiToCluster::produce(device::Event& iEvent, device::EventSetup const& iSetup) {
+    if (nDigis_ == 0) {
+      SiPixelClustersDevice clusters_d = SiPixelClustersDevice(pixelTopology::Phase1::numberOfModules, iEvent.queue());
+      iEvent.emplace(digiPutToken_, std::move(digis_d));
+      iEvent.emplace(clusterPutToken_, std::move(clusters_d));
+      if (includeErrors_) {
+        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsDevice());
+      }
+      return;
+    }
+
+    // auto tmp = Algo_.getResults();
+    iEvent.emplace(digiPutToken_, std::move(digis_d));
+    iEvent.emplace(clusterPutToken_, Algo_.getClusters());  //std::move(tmp.second));
+    if (includeErrors_) {
+      iEvent.emplace(digiErrorPutToken_, Algo_.getErrors());
+    }
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+// define as framework plugin
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(SiPixelPhase2DigiToCluster);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -1,0 +1,316 @@
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingUtilities.h"
+#include "CalibTracker/Records/interface/SiPixelMappingSoARecord.h"
+
+#include "CalibTracker/Records/interface/SiPixelGainCalibrationForHLTSoARcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
+
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "EventFilter/SiPixelRawToDigi/interface/PixelDataFormatter.h"
+#include "EventFilter/SiPixelRawToDigi/interface/PixelUnpackingRegions.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaCore/interface/ScopedContext.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+#include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
+#include "SiPixelRawToClusterKernel.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class SiPixelRawToCluster : public stream::SynchronizingEDProducer<> {
+  public:
+    explicit SiPixelRawToCluster(const edm::ParameterSet& iConfig);
+    ~SiPixelRawToCluster() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override;
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override;
+
+    // cms::alpakatools::ContextState<Queue> ctxState_;
+
+    edm::EDGetTokenT<FEDRawDataCollection> rawGetToken_;
+    device::EDPutToken<SiPixelDigisDevice> digiPutToken_;
+    device::EDPutToken<SiPixelDigiErrorsDevice> digiErrorPutToken_;
+    device::EDPutToken<SiPixelClustersDevice> clusterPutToken_;
+
+    edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher_;
+    const device::ESGetToken<SiPixelMappingDevice, SiPixelMappingSoARecord> mapToken_;
+    const device::ESGetToken<SiPixelGainCalibrationForHLTDevice, SiPixelGainCalibrationForHLTSoARcd> gainsToken_;
+    const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
+
+    std::unique_ptr<SiPixelFedCablingTree> cabling_;
+    std::vector<unsigned int> fedIds_;
+    const SiPixelFedCablingMap* cablingMap_ = nullptr;
+    std::unique_ptr<PixelUnpackingRegions> regions_;
+
+    pixelDetails::SiPixelRawToClusterKernel Algo_;
+    PixelDataFormatter::Errors errors_;
+
+    const bool isRun2_;
+    const bool includeErrors_;
+    const bool useQuality_;
+    uint32_t nDigis_;
+    const SiPixelClusterThresholds clusterThresholds_;
+  };
+
+  SiPixelRawToCluster::SiPixelRawToCluster(const edm::ParameterSet& iConfig)
+      : rawGetToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("InputLabel"))),
+        digiPutToken_(produces()),
+        clusterPutToken_(produces()),
+        mapToken_(esConsumes()),
+        gainsToken_(esConsumes()),
+        cablingMapToken_(esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>(
+            edm::ESInputTag("", iConfig.getParameter<std::string>("CablingMapLabel")))),
+        isRun2_(iConfig.getParameter<bool>("isRun2")),
+        includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),
+        useQuality_(iConfig.getParameter<bool>("UseQualityInfo")),
+        clusterThresholds_{iConfig.getParameter<int32_t>("clusterThreshold_layer1"),
+                           iConfig.getParameter<int32_t>("clusterThreshold_otherLayers")} {
+    if (includeErrors_) {
+      digiErrorPutToken_ =
+          produces();  //<cms::alpakatools::Product<alpaka_cuda_async::Queue,alpaka_cuda_async::SiPixelDigisDevice>>(); //reg.produces<cms::alpakatools::Product<Queue, SiPixelDigiErrorsAlpaka>>();
+    }
+
+    // regions
+    if (!iConfig.getParameter<edm::ParameterSet>("Regions").getParameterNames().empty()) {
+      regions_ = std::make_unique<PixelUnpackingRegions>(iConfig, consumesCollector());
+    }
+  }
+
+  void SiPixelRawToCluster::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<bool>("isRun2", true);
+    desc.add<bool>("IncludeErrors", true);
+    desc.add<bool>("UseQualityInfo", false);
+    // Note: this parameter is obsolete: it is ignored and will have no effect.
+    // It is kept to avoid breaking older configurations, and will not be printed in the generated cfi.py file.
+    desc.addOptionalNode(edm::ParameterDescription<uint32_t>("MaxFEDWords", 0, true), false)
+        ->setComment("This parameter is obsolete and will be ignored.");
+    desc.add<int32_t>("clusterThreshold_layer1", kSiPixelClusterThresholdsDefaultPhase1.layer1);
+    desc.add<int32_t>("clusterThreshold_otherLayers", kSiPixelClusterThresholdsDefaultPhase1.otherLayers);
+    desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
+    {
+      edm::ParameterSetDescription psd0;
+      psd0.addOptional<std::vector<edm::InputTag>>("inputs");
+      psd0.addOptional<std::vector<double>>("deltaPhi");
+      psd0.addOptional<std::vector<double>>("maxZ");
+      psd0.addOptional<edm::InputTag>("beamSpot");
+      desc.add<edm::ParameterSetDescription>("Regions", psd0)
+          ->setComment("## Empty Regions PSet means complete unpacking");
+    }
+    desc.add<std::string>("CablingMapLabel", "")->setComment("CablingMap label");  //Tav
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void SiPixelRawToCluster::acquire(device::Event const& iEvent, device::EventSetup const& iSetup) {
+    // cms::alpakatools::ScopedContextAcquire<Queue> ctx{iEvent.streamID(), std::move(waitingTaskHolder), ctxState_};
+
+    auto const& hMap = iSetup.getData(mapToken_);
+    if (SiPixelMappingUtilities::hasQuality(hMap.const_view()) != useQuality_) {
+      throw cms::Exception("LogicError")
+          << "UseQuality of the module (" << useQuality_
+          << ") differs the one from SiPixelROCsStatusAndMappingWrapper. Please fix your configuration.";
+    }
+    // get the GPU product already here so that the async transfer can begin
+    // const auto* Map = hMap.getGPUProductAsync(iEvent.queue());
+    // const unsigned char* ModulesToUnpack = hMap.getModToUnpAllAsync(iEvent.queue());
+
+    auto const& dGains = iSetup.getData(gainsToken_);
+
+    auto Gains = SiPixelGainCalibrationForHLTDevice(1, iEvent.queue());
+    auto modulesToUnpackRegional =
+        cms::alpakatools::make_device_buffer<unsigned char[]>(iEvent.queue(), ::pixelgpudetails::MAX_SIZE);
+    const unsigned char* modulesToUnpack;
+
+    // initialize cabling map or update if necessary
+    if (recordWatcher_.check(iSetup) or regions_) {
+      // cabling map, which maps online address (fed->link->ROC->local pixel) to offline (DetId->global pixel)
+      cablingMap_ = iSetup.getHandle(cablingMapToken_).product();
+      //cablingMap_ = cablingMap.product();
+      fedIds_ = cablingMap_->fedIds();
+      cabling_ = cablingMap_->cablingTree();
+      LogDebug("map version:") << cablingMap_->version();
+    }
+
+    if (regions_) {
+      regions_->run(iEvent, iSetup);
+      LogDebug("SiPixelRawToCluster") << "region2unpack #feds: " << regions_->nFEDs();
+      LogDebug("SiPixelRawToCluster") << "region2unpack #modules (BPIX,EPIX,total): " << regions_->nBarrelModules()
+                                      << " " << regions_->nForwardModules() << " " << regions_->nModules();
+
+      modulesToUnpackRegional = SiPixelMappingUtilities::getModToUnpRegionalAsync(
+          *(regions_->modulesToUnpack()), (cablingMap_->cablingTree()).get(), cablingMap_->fedIds(), iEvent.queue());
+      modulesToUnpack = modulesToUnpackRegional.data();
+    } else {
+      modulesToUnpack = hMap->modToUnpDefault();
+    }
+
+    const auto& buffers = iEvent.get(rawGetToken_);
+
+    errors_.clear();
+
+    // GPU specific: Data extraction for RawToDigi GPU
+    unsigned int wordCounter = 0;
+    unsigned int fedCounter = 0;
+    bool errorsInEvent = false;
+
+    std::vector<unsigned int> index(fedIds_.size(), 0);
+    std::vector<cms_uint32_t const*> start(fedIds_.size(), nullptr);
+    std::vector<ptrdiff_t> words(fedIds_.size(), 0);
+
+    // In CPU algorithm this loop is part of PixelDataFormatter::interpretRawData()
+    ErrorChecker errorcheck;
+    for (uint32_t i = 0; i < fedIds_.size(); ++i) {
+      const int fedId = fedIds_[i];
+      if (regions_ && !regions_->mayUnpackFED(fedId))
+        continue;
+
+      // for GPU
+      // first 150 index stores the fedId and next 150 will store the
+      // start index of word in that fed
+      assert(fedId >= FEDNumbering::MINSiPixeluTCAFEDID);
+      fedCounter++;
+
+      // get event data for this fed
+      const FEDRawData& rawData = buffers.FEDData(fedId);
+
+      // GPU specific
+      int nWords = rawData.size() / sizeof(cms_uint64_t);
+      if (nWords == 0) {
+        continue;
+      }
+
+      // check CRC bit
+      const cms_uint64_t* trailer = reinterpret_cast<const cms_uint64_t*>(rawData.data()) + (nWords - 1);
+      if (not errorcheck.checkCRC(errorsInEvent, fedId, trailer, errors_)) {
+        continue;
+      }
+
+      // check headers
+      const cms_uint64_t* header = reinterpret_cast<const cms_uint64_t*>(rawData.data());
+      header--;
+      bool moreHeaders = true;
+      while (moreHeaders) {
+        header++;
+        bool headerStatus = errorcheck.checkHeader(errorsInEvent, fedId, header, errors_);
+        moreHeaders = headerStatus;
+      }
+
+      // check trailers
+      bool moreTrailers = true;
+      trailer++;
+      while (moreTrailers) {
+        trailer--;
+        bool trailerStatus = errorcheck.checkTrailer(errorsInEvent, fedId, nWords, trailer, errors_);
+        moreTrailers = trailerStatus;
+      }
+
+      const cms_uint32_t* bw = (const cms_uint32_t*)(header + 1);
+      const cms_uint32_t* ew = (const cms_uint32_t*)(trailer);
+
+      assert(0 == (ew - bw) % 2);
+      index[i] = wordCounter;
+      start[i] = bw;
+      words[i] = (ew - bw);
+      wordCounter += (ew - bw);
+
+    }  // end of for loop
+
+    nDigis_ = wordCounter;
+
+    if (nDigis_ == 0)
+      return;
+
+    // copy the FED data to a single cpu buffer
+    pixelDetails::SiPixelRawToClusterKernel::WordFedAppender wordFedAppender(nDigis_);
+    for (uint32_t i = 0; i < fedIds_.size(); ++i) {
+      wordFedAppender.initializeWordFed(fedIds_[i], index[i], start[i], words[i]);
+    }
+
+    Algo_.makeClustersAsync(isRun2_,
+                            clusterThresholds_,
+                            hMap.const_view(),
+                            modulesToUnpack,
+                            dGains.const_view(),
+                            wordFedAppender,
+                            std::move(errors_),
+                            wordCounter,
+                            fedCounter,
+                            useQuality_,
+                            includeErrors_,
+                            edm::MessageDrop::instance()->debugEnabled,
+                            iEvent.queue());
+  }
+
+  void SiPixelRawToCluster::produce(device::Event& iEvent, device::EventSetup const& iSetup) {
+    if (nDigis_ == 0) {
+      // Cannot use the default constructor here, as it would not allocate memory.
+      // In the case of no digis, clusters_d are not being instantiated, but are
+      // still used downstream to initialize TrackingRecHitSoADevice. If there
+      // are no valid pointers to clusters' Collection columns, instantiation
+      // of TrackingRecHits fail. Example: workflow 11604.0
+      SiPixelDigisDevice digis_d = SiPixelDigisDevice(nDigis_, iEvent.queue());
+      SiPixelClustersDevice clusters_d = SiPixelClustersDevice(pixelTopology::Phase1::numberOfModules, iEvent.queue());
+      iEvent.emplace(digiPutToken_, std::move(digis_d));
+      iEvent.emplace(clusterPutToken_, std::move(clusters_d));
+      if (includeErrors_) {
+        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsDevice());
+      }
+      return;
+    }
+
+    // auto tmp = Algo_.getResults();
+    iEvent.emplace(digiPutToken_, Algo_.getDigis());  //std::move(tmp.first));
+    iEvent.emplace(clusterPutToken_, Algo_.getClusters());
+    if (includeErrors_) {
+      iEvent.emplace(digiErrorPutToken_, Algo_.getErrors());
+    }
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+// define as framework plugin
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(SiPixelRawToCluster);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -20,8 +20,8 @@
 #include <utility>
 
 // CMSSW includes
-#include "HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -1,0 +1,862 @@
+/* Sushil Dubey, Shashi Dugad, TIFR, July 2017
+ *
+ * File Name: RawToClusterGPU.cu
+ * Description: It converts Raw data into Digi Format on GPU
+ * Finaly the Output of RawToDigi data is given to pixelClusterizer
+ *
+**/
+
+// C++ includes
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <utility>
+
+// CMSSW includes
+#include "HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelMappingLayout.h"
+#include "DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h"
+
+// local includes
+#include "CalibPixel.h"
+#include "ClusterChargeCut.h"
+#include "PixelClustering.h"
+#include "SiPixelRawToClusterKernel.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace pixelDetails {
+
+    SiPixelRawToClusterKernel::WordFedAppender::WordFedAppender(uint32_t words)
+        : word_{cms::alpakatools::make_host_buffer<unsigned int[], Platform>(words)},
+          fedId_{cms::alpakatools::make_host_buffer<unsigned char[], Platform>(words)} {}
+
+    void SiPixelRawToClusterKernel::WordFedAppender::initializeWordFed(int fedId,
+                                                                       unsigned int wordCounterGPU,
+                                                                       const uint32_t *src,
+                                                                       unsigned int length) {
+      std::memcpy(word_.data() + wordCounterGPU, src, sizeof(uint32_t) * length);
+      std::memset(fedId_.data() + wordCounterGPU / 2, fedId - 1200, length / 2);
+    }
+
+    ////////////////////
+
+    ALPAKA_FN_ACC uint32_t getLink(uint32_t ww) {
+      return ((ww >> ::sipixelconstants::LINK_shift) & ::sipixelconstants::LINK_mask);
+    }
+
+    ALPAKA_FN_ACC uint32_t getRoc(uint32_t ww) {
+      return ((ww >> ::sipixelconstants::ROC_shift) & ::sipixelconstants::ROC_mask);
+    }
+
+    ALPAKA_FN_ACC uint32_t getADC(uint32_t ww) {
+      return ((ww >> ::sipixelconstants::ADC_shift) & ::sipixelconstants::ADC_mask);
+    }
+
+    ALPAKA_FN_ACC bool isBarrel(uint32_t rawId) { return (1 == ((rawId >> 25) & 0x7)); }
+
+    ALPAKA_FN_ACC ::pixelDetails::DetIdGPU getRawId(const SiPixelMappingLayoutSoAConstView &cablingMap,
+                                                    uint8_t fed,
+                                                    uint32_t link,
+                                                    uint32_t roc) {
+      using namespace ::pixelDetails;
+      uint32_t index = fed * MAX_LINK * MAX_ROC + (link - 1) * MAX_ROC + roc;
+      ::pixelDetails::DetIdGPU detId = {
+          cablingMap.rawId()[index], cablingMap.rocInDet()[index], cablingMap.moduleId()[index]};
+      return detId;
+    }
+
+    //reference http://cmsdoxygen.web.cern.ch/cmsdoxygen/CMSSW_9_2_0/doc/html/dd/d31/FrameConversion_8cc_source.html
+    //http://cmslxr.fnal.gov/source/CondFormats/SiPixelObjects/src/PixelROC.cc?v=CMSSW_9_2_0#0071
+    // Convert local pixel to pixelDetails::global pixel
+    ALPAKA_FN_ACC ::pixelDetails::Pixel frameConversion(
+        bool bpix, int side, uint32_t layer, uint32_t rocIdInDetUnit, ::pixelDetails::Pixel local) {
+      int slopeRow = 0, slopeCol = 0;
+      int rowOffset = 0, colOffset = 0;
+
+      if (bpix) {
+        if (side == -1 && layer != 1) {  // -Z side: 4 non-flipped modules oriented like 'dddd', except Layer 1
+          if (rocIdInDetUnit < 8) {
+            slopeRow = 1;
+            slopeCol = -1;
+            rowOffset = 0;
+            colOffset = (8 - rocIdInDetUnit) * ::pixelDetails::numColsInRoc - 1;
+          } else {
+            slopeRow = -1;
+            slopeCol = 1;
+            rowOffset = 2 * ::pixelDetails::numRowsInRoc - 1;
+            colOffset = (rocIdInDetUnit - 8) * ::pixelDetails::numColsInRoc;
+          }       // if roc
+        } else {  // +Z side: 4 non-flipped modules oriented like 'pppp', but all 8 in layer1
+          if (rocIdInDetUnit < 8) {
+            slopeRow = -1;
+            slopeCol = 1;
+            rowOffset = 2 * ::pixelDetails::numRowsInRoc - 1;
+            colOffset = rocIdInDetUnit * ::pixelDetails::numColsInRoc;
+          } else {
+            slopeRow = 1;
+            slopeCol = -1;
+            rowOffset = 0;
+            colOffset = (16 - rocIdInDetUnit) * ::pixelDetails::numColsInRoc - 1;
+          }
+        }
+
+      } else {             // fpix
+        if (side == -1) {  // pannel 1
+          if (rocIdInDetUnit < 8) {
+            slopeRow = 1;
+            slopeCol = -1;
+            rowOffset = 0;
+            colOffset = (8 - rocIdInDetUnit) * ::pixelDetails::numColsInRoc - 1;
+          } else {
+            slopeRow = -1;
+            slopeCol = 1;
+            rowOffset = 2 * ::pixelDetails::numRowsInRoc - 1;
+            colOffset = (rocIdInDetUnit - 8) * ::pixelDetails::numColsInRoc;
+          }
+        } else {  // pannel 2
+          if (rocIdInDetUnit < 8) {
+            slopeRow = 1;
+            slopeCol = -1;
+            rowOffset = 0;
+            colOffset = (8 - rocIdInDetUnit) * ::pixelDetails::numColsInRoc - 1;
+          } else {
+            slopeRow = -1;
+            slopeCol = 1;
+            rowOffset = 2 * ::pixelDetails::numRowsInRoc - 1;
+            colOffset = (rocIdInDetUnit - 8) * ::pixelDetails::numColsInRoc;
+          }
+
+        }  // side
+      }
+
+      uint32_t gRow = rowOffset + slopeRow * local.row;
+      uint32_t gCol = colOffset + slopeCol * local.col;
+      //printf("Inside frameConversion row: %u, column: %u\n", gRow, gCol);
+      ::pixelDetails::Pixel global = {gRow, gCol};
+      return global;
+    }
+
+    ALPAKA_FN_ACC uint8_t conversionError(uint8_t fedId, uint8_t status, bool debug = false) {
+      uint8_t errorType = 0;
+
+      // debug = true;
+
+      switch (status) {
+        case (1): {
+          if (debug)
+            printf("Error in Fed: %i, invalid channel Id (errorType = 35\n)", fedId);
+          errorType = 35;
+          break;
+        }
+        case (2): {
+          if (debug)
+            printf("Error in Fed: %i, invalid ROC Id (errorType = 36)\n", fedId);
+          errorType = 36;
+          break;
+        }
+        case (3): {
+          if (debug)
+            printf("Error in Fed: %i, invalid dcol/pixel value (errorType = 37)\n", fedId);
+          errorType = 37;
+          break;
+        }
+        case (4): {
+          if (debug)
+            printf("Error in Fed: %i, dcol/pixel read out of order (errorType = 38)\n", fedId);
+          errorType = 38;
+          break;
+        }
+        default:
+          if (debug)
+            printf("Cabling check returned unexpected result, status = %i\n", status);
+      };
+
+      return errorType;
+    }
+
+    ALPAKA_FN_ACC bool rocRowColIsValid(uint32_t rocRow, uint32_t rocCol) {
+      uint32_t numRowsInRoc = 80;
+      uint32_t numColsInRoc = 52;
+
+      /// row and collumn in ROC representation
+      return ((rocRow < numRowsInRoc) & (rocCol < numColsInRoc));
+    }
+
+    ALPAKA_FN_ACC bool dcolIsValid(uint32_t dcol, uint32_t pxid) { return ((dcol < 26) & (2 <= pxid) & (pxid < 162)); }
+
+    ALPAKA_FN_ACC uint8_t checkROC(uint32_t errorWord,
+                                   uint8_t fedId,
+                                   uint32_t link,
+                                   const SiPixelMappingLayoutSoAConstView &cablingMap,
+                                   bool debug = false) {
+      uint8_t errorType = (errorWord >> ::pixelDetails::ROC_shift) & ::pixelDetails::ERROR_mask;
+      if (errorType < 25)
+        return 0;
+      bool errorFound = false;
+
+      switch (errorType) {
+        case (25): {
+          errorFound = true;
+          uint32_t index =
+              fedId * ::pixelDetails::MAX_LINK * ::pixelDetails::MAX_ROC + (link - 1) * ::pixelDetails::MAX_ROC + 1;
+          if (index > 1 && index <= cablingMap.size()) {
+            if (!(link == cablingMap.link()[index] && 1 == cablingMap.roc()[index]))
+              errorFound = false;
+          }
+          if (debug and errorFound)
+            printf("Invalid ROC = 25 found (errorType = 25)\n");
+          break;
+        }
+        case (26): {
+          if (debug)
+            printf("Gap word found (errorType = 26)\n");
+          errorFound = true;
+          break;
+        }
+        case (27): {
+          if (debug)
+            printf("Dummy word found (errorType = 27)\n");
+          errorFound = true;
+          break;
+        }
+        case (28): {
+          if (debug)
+            printf("Error fifo nearly full (errorType = 28)\n");
+          errorFound = true;
+          break;
+        }
+        case (29): {
+          if (debug)
+            printf("Timeout on a channel (errorType = 29)\n");
+          if ((errorWord >> ::pixelDetails::OMIT_ERR_shift) & ::pixelDetails::OMIT_ERR_mask) {
+            if (debug)
+              printf("...first errorType=29 error, this gets masked out\n");
+          }
+          errorFound = true;
+          break;
+        }
+        case (30): {
+          if (debug)
+            printf("TBM error trailer (errorType = 30)\n");
+          int StateMatch_bits = 4;
+          int StateMatch_shift = 8;
+          uint32_t StateMatch_mask = ~(~uint32_t(0) << StateMatch_bits);
+          int StateMatch = (errorWord >> StateMatch_shift) & StateMatch_mask;
+          if (StateMatch != 1 && StateMatch != 8) {
+            if (debug)
+              printf("FED error 30 with unexpected State Bits (errorType = 30)\n");
+          }
+          if (StateMatch == 1)
+            errorType = 40;  // 1=Overflow -> 40, 8=number of ROCs -> 30
+          errorFound = true;
+          break;
+        }
+        case (31): {
+          if (debug)
+            printf("Event number error (errorType = 31)\n");
+          errorFound = true;
+          break;
+        }
+        default:
+          errorFound = false;
+      };
+
+      return errorFound ? errorType : 0;
+    }
+
+    ALPAKA_FN_ACC uint32_t getErrRawID(uint8_t fedId,
+                                       uint32_t errWord,
+                                       uint32_t errorType,
+                                       const SiPixelMappingLayoutSoAConstView &cablingMap,
+                                       bool debug = false) {
+      uint32_t rID = 0xffffffff;
+
+      switch (errorType) {
+        case 25:
+        case 30:
+        case 31:
+        case 36:
+        case 40: {
+          //set dummy values for cabling just to get detId from link
+          //cabling.dcol = 0;
+          //cabling.pxid = 2;
+          uint32_t roc = 1;
+          uint32_t link = (errWord >> ::pixelDetails::LINK_shift) & ::pixelDetails::LINK_mask;
+          uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).RawId;
+          if (rID_temp != 9999)
+            rID = rID_temp;
+          break;
+        }
+        case 29: {
+          int chanNmbr = 0;
+          const int DB0_shift = 0;
+          const int DB1_shift = DB0_shift + 1;
+          const int DB2_shift = DB1_shift + 1;
+          const int DB3_shift = DB2_shift + 1;
+          const int DB4_shift = DB3_shift + 1;
+          const uint32_t DataBit_mask = ~(~uint32_t(0) << 1);
+
+          int CH1 = (errWord >> DB0_shift) & DataBit_mask;
+          int CH2 = (errWord >> DB1_shift) & DataBit_mask;
+          int CH3 = (errWord >> DB2_shift) & DataBit_mask;
+          int CH4 = (errWord >> DB3_shift) & DataBit_mask;
+          int CH5 = (errWord >> DB4_shift) & DataBit_mask;
+          int BLOCK_bits = 3;
+          int BLOCK_shift = 8;
+          uint32_t BLOCK_mask = ~(~uint32_t(0) << BLOCK_bits);
+          int BLOCK = (errWord >> BLOCK_shift) & BLOCK_mask;
+          int localCH = 1 * CH1 + 2 * CH2 + 3 * CH3 + 4 * CH4 + 5 * CH5;
+          if (BLOCK % 2 == 0)
+            chanNmbr = (BLOCK / 2) * 9 + localCH;
+          else
+            chanNmbr = ((BLOCK - 1) / 2) * 9 + 4 + localCH;
+          if ((chanNmbr < 1) || (chanNmbr > 36))
+            break;  // signifies unexpected result
+
+          // set dummy values for cabling just to get detId from link if in Barrel
+          //cabling.dcol = 0;
+          //cabling.pxid = 2;
+          uint32_t roc = 1;
+          uint32_t link = chanNmbr;
+          uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).RawId;
+          if (rID_temp != 9999)
+            rID = rID_temp;
+          break;
+        }
+        case 37:
+        case 38: {
+          //cabling.dcol = 0;
+          //cabling.pxid = 2;
+          uint32_t roc = (errWord >> ::pixelDetails::ROC_shift) & ::pixelDetails::ROC_mask;
+          uint32_t link = (errWord >> ::pixelDetails::LINK_shift) & ::pixelDetails::LINK_mask;
+          uint32_t rID_temp = getRawId(cablingMap, fedId, link, roc).RawId;
+          if (rID_temp != 9999)
+            rID = rID_temp;
+          break;
+        }
+        default:
+          break;
+      };
+
+      return rID;
+    }
+
+    // Kernel to perform Raw to Digi conversion
+    struct RawToDigi_kernel {
+      template <typename TAcc>
+      ALPAKA_FN_ACC void operator()(const TAcc &acc,
+                                    // const SiPixelFedCablingMapGPU *cablingMap,
+                                    const SiPixelMappingLayoutSoAConstView &cablingMap,
+                                    const unsigned char *modToUnp,
+                                    const uint32_t wordCounter,
+                                    const uint32_t *word,
+                                    const uint8_t *fedIds,
+                                    SiPixelDigisLayoutSoAView digisView,
+                                    // uint16_t *xx,
+                                    // uint16_t *yy,
+                                    // uint16_t *adc,
+                                    // uint32_t *pdigi,
+                                    // uint32_t *rawIdArr,
+                                    // uint16_t *moduleId,
+                                    cms::alpakatools::SimpleVector<SiPixelErrorCompact> *err,
+                                    bool useQualityInfo,
+                                    bool includeErrors,
+                                    bool debug) const {
+        cms::alpakatools::for_each_element_in_grid_strided(acc, wordCounter, [&](uint32_t iloop) {
+          auto gIndex = iloop;
+          auto dvgi = digisView[gIndex];
+          dvgi.xx() = 0;
+          dvgi.yy() = 0;
+          dvgi.adc() = 0;
+          bool skipROC = false;
+
+          uint8_t fedId = fedIds[gIndex / 2];  // +1200;
+
+          // initialize (too many coninue below)
+          dvgi.pdigi() = 0;
+          dvgi.rawIdArr() = 0;
+          dvgi.moduleId() = 9999;
+
+          uint32_t ww = word[gIndex];  // Array containing 32 bit raw data
+          if (ww == 0) {
+            // 0 is an indicator of a noise/dead channel, skip these pixels during clusterization
+            return;
+          }
+
+          uint32_t link = getLink(ww);  // Extract link
+          uint32_t roc = getRoc(ww);    // Extract Roc in link
+          ::pixelDetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
+
+          uint8_t errorType = checkROC(ww, fedId, link, cablingMap, debug);
+          skipROC = (roc < ::pixelDetails::maxROCIndex) ? false : (errorType != 0);
+          if (includeErrors and skipROC) {
+            uint32_t rID = getErrRawID(fedId, ww, errorType, cablingMap, debug);
+            err->push_back(acc, SiPixelErrorCompact{rID, ww, errorType, fedId});
+            return;
+          }
+
+          uint32_t rawId = detId.RawId;
+          uint32_t rocIdInDetUnit = detId.rocInDet;
+          bool barrel = isBarrel(rawId);
+
+          uint32_t index =
+              fedId * ::pixelDetails::MAX_LINK * ::pixelDetails::MAX_ROC + (link - 1) * ::pixelDetails::MAX_ROC + roc;
+          if (useQualityInfo) {
+            skipROC = cablingMap.badRocs()[index];
+            if (skipROC)
+              return;
+          }
+          skipROC = modToUnp[index];
+          if (skipROC)
+            return;
+
+          uint32_t layer = 0;                   //, ladder =0;
+          int side = 0, panel = 0, module = 0;  //disk = 0, blade = 0
+
+          if (barrel) {
+            layer = (rawId >> ::pixelDetails::layerStartBit) & ::pixelDetails::layerMask;
+            module = (rawId >> ::pixelDetails::moduleStartBit) & ::pixelDetails::moduleMask;
+            side = (module < 5) ? -1 : 1;
+          } else {
+            // endcap ids
+            layer = 0;
+            panel = (rawId >> ::pixelDetails::panelStartBit) & ::pixelDetails::panelMask;
+            //disk  = (rawId >> diskStartBit_) & diskMask_;
+            side = (panel == 1) ? -1 : 1;
+            //blade = (rawId >> bladeStartBit_) & bladeMask_;
+          }
+
+          // ***special case of layer to 1 be handled here
+          ::pixelDetails::Pixel localPix;
+          if (layer == 1) {
+            uint32_t col = (ww >> ::pixelDetails::COL_shift) & ::pixelDetails::COL_mask;
+            uint32_t row = (ww >> ::pixelDetails::ROW_shift) & ::pixelDetails::ROW_mask;
+            localPix.row = row;
+            localPix.col = col;
+            if (includeErrors) {
+              if (not rocRowColIsValid(row, col)) {
+                uint8_t error = conversionError(fedId, 3, debug);  //use the device function and fill the arrays
+                err->push_back(acc, SiPixelErrorCompact{rawId, ww, error, fedId});
+                if (debug)
+                  printf("BPIX1  Error status: %i\n", error);
+                return;
+              }
+            }
+          } else {
+            // ***conversion rules for dcol and pxid
+            uint32_t dcol = (ww >> ::pixelDetails::DCOL_shift) & ::pixelDetails::DCOL_mask;
+            uint32_t pxid = (ww >> ::pixelDetails::PXID_shift) & ::pixelDetails::PXID_mask;
+            uint32_t row = ::pixelDetails::numRowsInRoc - pxid / 2;
+            uint32_t col = dcol * 2 + pxid % 2;
+            localPix.row = row;
+            localPix.col = col;
+            if (includeErrors and not dcolIsValid(dcol, pxid)) {
+              uint8_t error = conversionError(fedId, 3, debug);
+              err->push_back(acc, SiPixelErrorCompact{rawId, ww, error, fedId});
+              if (debug)
+                printf("Error status: %i %d %d %d %d\n", error, dcol, pxid, fedId, roc);
+              return;
+            }
+          }
+
+          ::pixelDetails::Pixel globalPix = frameConversion(barrel, side, layer, rocIdInDetUnit, localPix);
+          dvgi.xx() = globalPix.row;  // origin shifting by 1 0-159
+          dvgi.yy() = globalPix.col;  // origin shifting by 1 0-415
+          dvgi.adc() = getADC(ww);
+          dvgi.pdigi() = ::pixelDetails::pack(globalPix.row, globalPix.col, dvgi.adc());
+          dvgi.moduleId() = detId.moduleId;
+          dvgi.rawIdArr() = rawId;
+        });  // end of stride on grid
+
+      }  // end of Raw to Digi kernel operator()
+    };   // end of Raw to Digi struct
+
+  }  // namespace pixelDetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace pixelDetails {
+
+  template <typename TrackerTraits>
+  struct fillHitsModuleStart {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(const TAcc &acc,
+                                  // uint32_t const *__restrict__ cluStart,
+                                  SiPixelClustersLayoutSoAView clus_view
+                                  // uint32_t *__restrict__ moduleStart
+    ) const {
+      ALPAKA_ASSERT_OFFLOAD(TrackerTraits::numberOfModules < 2048);  // easy to extend at least till 32*1024
+
+      constexpr int nMaxModules = TrackerTraits::numberOfModules;
+
+#ifndef NDEBUG
+      [[maybe_unused]] const uint32_t blockIdxLocal(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      ALPAKA_ASSERT_OFFLOAD(0 == blockIdxLocal);
+      [[maybe_unused]] const uint32_t gridDimension(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+      ALPAKA_ASSERT_OFFLOAD(1 == gridDimension);
+#endif
+
+      // limit to MaxHitsInModule;
+      cms::alpakatools::for_each_element_in_block_strided(acc, nMaxModules, [&](uint32_t i) {
+        clus_view[i + 1].moduleStart() = std::min(pixelClustering::maxHitsInModule(), clus_view[i].clusInModule());
+      });
+
+      constexpr bool isPhase2 = std::is_base_of<pixelTopology::Phase2, TrackerTraits>::value;
+      constexpr auto leftModules = isPhase2 ? 1024 : nMaxModules - 1024;
+
+      auto &&ws = alpaka::declareSharedVar<uint32_t[32], __COUNTER__>(acc);
+      cms::alpakatools::blockPrefixScan(acc, clus_view.moduleStart() + 1, clus_view.moduleStart() + 1, 1024, ws);
+      cms::alpakatools::blockPrefixScan(
+          acc, clus_view.moduleStart() + 1024 + 1, clus_view.moduleStart() + 1024 + 1, leftModules, ws);
+
+      if constexpr (isPhase2) {
+        cms::alpakatools::blockPrefixScan(
+            acc, clus_view.moduleStart() + 2048 + 1, clus_view.moduleStart() + 2048 + 1, 1024, ws);
+        cms::alpakatools::blockPrefixScan(
+            acc, clus_view.moduleStart() + 3072 + 1, clus_view.moduleStart() + 3072 + 1, nMaxModules - 3072, ws);
+      }
+
+      constexpr auto lastModule = isPhase2 ? 2049u : nMaxModules + 1;
+      cms::alpakatools::for_each_element_in_block_strided(
+          acc, lastModule, 1025u, [&](uint32_t i) { clus_view[i].moduleStart() += clus_view[1024].moduleStart(); });
+      alpaka::syncBlockThreads(acc);
+
+      if constexpr (isPhase2) {
+        cms::alpakatools::for_each_element_in_block_strided(
+            acc, 3073u, 2049u, [&](uint32_t i) { clus_view[i].moduleStart() += clus_view[2048].moduleStart(); });
+        alpaka::syncBlockThreads(acc);
+
+        cms::alpakatools::for_each_element_in_block_strided(acc, nMaxModules + 1, 3073u, [&](uint32_t i) {
+          clus_view[i].moduleStart() += clus_view[3072].moduleStart();
+        });
+        alpaka::syncBlockThreads(acc);
+      }
+#ifdef GPU_DEBUG
+      ALPAKA_ASSERT_OFFLOAD(0 == clus_view.[0].moduleStart());
+      auto c0 = std::min(pixelClustering::maxHitsInModule(), cluStart[0]);
+      ALPAKA_ASSERT_OFFLOAD(c0 == clus_view.[1].moduleStart());
+      ALPAKA_ASSERT_OFFLOAD(clus_view.[1024].moduleStart() >= clus_view.[1023].moduleStart());
+      ALPAKA_ASSERT_OFFLOAD(clus_view.[1025].moduleStart() >= clus_view.[1024].moduleStart());
+      ALPAKA_ASSERT_OFFLOAD(clus_view.[nMaxModules].moduleStart() >= clus_view.[1025].moduleStart());
+
+      //for (int i = first, iend = nMaxModules + 1; i < iend; i += blockDim.x) {
+      cms::alpakatools::for_each_element_in_block_strided(acc, nMaxModules + 1, [&](uint32_t i) {
+        if (0 != i)
+          ALPAKA_ASSERT_OFFLOAD(clus_view[i].moduleStart() >= clus_view[i - i].moduleStart());
+        // [BPX1, BPX2, BPX3, BPX4,  FP1,  FP2,  FP3,  FN1,  FN2,  FN3, LAST_VALID]
+        // [   0,   96,  320,  672, 1184, 1296, 1408, 1520, 1632, 1744,       1856]
+        if (i == 96 || i == 1184 || i == 1744 || i == nMaxModules)
+          printf("moduleStart %d %d\n", i, clus_view[i].moduleStart());
+      });
+#endif
+
+      // avoid overflow
+      constexpr auto MAX_HITS = 200000;  //pixelClustering::MaxNumClusters; //FIXME: in TrackerTraits
+      cms::alpakatools::for_each_element_in_block_strided(acc, nMaxModules + 1, [&](uint32_t i) {
+        if (clus_view[i].moduleStart() > MAX_HITS)
+          clus_view[i].moduleStart() = MAX_HITS;
+      });
+
+    }  // end of fillHitsModuleStart kernel operator()
+  };   // end of fillHitsModuleStart struct
+
+}  // namespace pixelDetails
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace pixelDetails {
+
+    // Interface to outside
+    void SiPixelRawToClusterKernel::makeClustersAsync(bool isRun2,
+                                                      const SiPixelClusterThresholds clusterThresholds,
+                                                      //  const SiPixelFedCablingMapGPU *cablingMap,
+                                                      const SiPixelMappingLayoutSoAConstView &cablingMap,
+                                                      const unsigned char *modToUnp,
+                                                      //  const SiPixelGainForHLTonGPU *gains,
+                                                      const SiPixelGainCalibrationForHLTSoAConstView &gains,
+                                                      const WordFedAppender &wordFed,
+                                                      SiPixelFormatterErrors &&errors,
+                                                      const uint32_t wordCounter,
+                                                      const uint32_t fedCounter,
+                                                      bool useQualityInfo,
+                                                      bool includeErrors,
+                                                      bool debug,
+                                                      Queue &queue) {
+      nDigis = wordCounter;
+
+#ifdef GPU_DEBUG
+      std::cout << "decoding " << wordCounter << " digis." << std::endl;
+#endif
+
+      constexpr int numberOfModules = pixelTopology::Phase1::numberOfModules;
+      digis_d = SiPixelDigisDevice(wordCounter, queue);
+      if (includeErrors) {
+        digiErrors_d = SiPixelDigiErrorsDevice(wordCounter, std::move(errors), queue);
+      }
+      clusters_d = SiPixelClustersDevice(numberOfModules, queue);
+
+      if (wordCounter)  // protect in case of empty event....
+      {
+#if defined(ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND) || defined(ALPAKA_ACC_GPU_HIP_ASYNC_BACKEND)
+        const int threadsPerBlockOrElementsPerThread = 512;
+#else
+        // NB: MPORTANT: This could be tuned to benefit from innermost loop.
+        const int threadsPerBlockOrElementsPerThread = 32;
+#endif
+        // fill it all
+        const uint32_t blocks = cms::alpakatools::divide_up_by(wordCounter, threadsPerBlockOrElementsPerThread);
+        const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlockOrElementsPerThread);
+
+        ALPAKA_ASSERT_OFFLOAD(0 == wordCounter % 2);
+        // wordCounter is the total no of words in each event to be trasfered on device
+        auto word_d = cms::alpakatools::make_device_buffer<uint32_t[]>(queue, wordCounter);
+        // NB: IMPORTANT: fedId_d: In legacy, wordCounter elements are allocated.
+        // However, only the first half of elements end up eventually used:
+        // hence, here, only wordCounter/2 elements are allocated.
+        auto fedId_d = cms::alpakatools::make_device_buffer<uint8_t[]>(queue, wordCounter / 2);
+
+        alpaka::memcpy(queue, word_d, wordFed.word(), wordCounter);
+        alpaka::memcpy(queue, fedId_d, wordFed.fedId(), wordCounter / 2);
+
+        // Launch rawToDigi kernel
+        alpaka::enqueue(queue,
+                        alpaka::createTaskKernel<Acc1D>(workDiv,
+                                                        RawToDigi_kernel(),
+                                                        cablingMap,
+                                                        modToUnp,
+                                                        wordCounter,
+                                                        word_d.data(),
+                                                        fedId_d.data(),
+                                                        digis_d->view(),
+                                                        // digis_d->xx(),
+                                                        // digis_d->yy(),
+                                                        // digis_d->adc(),
+                                                        // digis_d->pdigi(),
+                                                        // digis_d->rawIdArr(),
+                                                        // digis_d->moduleInd(),
+                                                        digiErrors_d->error(),
+                                                        useQualityInfo,
+                                                        includeErrors,
+                                                        debug));
+
+#ifdef GPU_DEBUG
+        alpaka::wait(queue);
+#endif
+
+#ifdef TODO
+        if (includeErrors) {
+          digiErrors_d.copyErrorToHostAsync(stream);
+        }
+#endif
+      }
+      // End of Raw2Digi and passing data for clustering
+
+      {
+        // clusterizer
+        using namespace pixelClustering;
+        // calibrations
+        using namespace calibPixel;
+#if defined(ALPAKA_ACC_GPU_CUDA_ASYNC_BACKEND) || defined(ALPAKA_ACC_GPU_HIP_ASYNC_BACKEND)
+        const auto threadsPerBlockOrElementsPerThread = 256;
+#else
+        // NB: MPORTANT: This could be tuned to benefit from innermost loop.
+        const auto threadsPerBlockOrElementsPerThread = 32;
+#endif
+        const auto blocks = cms::alpakatools::divide_up_by(std::max<int>(wordCounter, numberOfModules),
+                                                           threadsPerBlockOrElementsPerThread);
+        const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlockOrElementsPerThread);
+
+        // alpaka::enqueue(queue, alpaka::createTaskKernel<Acc1D>(workDiv, calibDigis(),
+        //                     isRun2,
+        //                     digis_d->view(),
+        //                     clusters_d->view(),
+        //                     gains,
+        //                     wordCounter));
+
+#ifdef GPU_DEBUG
+        alpaka::wait(queue);
+        std::cout << "CUDA countModules kernel launch with " << blocks << " blocks of "
+                  << threadsPerBlockOrElementsPerThread << " threadsPerBlockOrElementsPerThread\n";
+#endif
+
+        alpaka::enqueue(
+            queue,
+            alpaka::createTaskKernel<Acc1D>(
+                workDiv, countModules<pixelTopology::Phase1>(), digis_d->view(), clusters_d->view(), wordCounter));
+
+        auto moduleStartFirstElement =
+            cms::alpakatools::make_device_view(alpaka::getDev(queue), clusters_d->view().moduleStart(), 1u);
+        alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
+
+        const auto workDivMaxNumModules = cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, 256);
+        // NB: With present findClus() / chargeCut() algorithm,
+        // threadPerBlock (GPU) or elementsPerThread (CPU) = 256 show optimal performance.
+        // Though, it does not have to be the same number for CPU/GPU cases.
+
+#ifdef GPU_DEBUG
+        std::cout << "CUDA findClus kernel launch with " << numberOfModules << " blocks of " << 256
+                  << " threadsPerBlockOrElementsPerThread\n";
+#endif
+
+        alpaka::enqueue(queue,
+                        alpaka::createTaskKernel<Acc1D>(workDivMaxNumModules,
+                                                        findClus<pixelTopology::Phase1>(),
+                                                        digis_d->view(),
+                                                        clusters_d->view(),
+                                                        wordCounter));
+        // template <typename TAcc>
+        //       ALPAKA_FN_ACC void operator()(
+        //           const TAcc& acc,
+        //           SiPixelDigisLayoutSoAView digi_view,
+        //           SiPixelClustersLayoutSoAView clus_view,
+        //           const unsigned int numElements)
+
+#ifdef GPU_DEBUG
+        alpaka::wait(queue);
+#endif
+
+        // apply charge cut
+        alpaka::enqueue(queue,
+                        alpaka::createTaskKernel<Acc1D>(workDivMaxNumModules,
+                                                        ::pixelClustering::clusterChargeCut<pixelTopology::Phase1>(),
+                                                        digis_d->view(),
+                                                        clusters_d->view(),
+                                                        clusterThresholds,
+                                                        wordCounter));
+
+        // count the module start indices already here (instead of
+        // rechits) so that the number of clusters/hits can be made
+        // available in the rechit producer without additional points of
+        // synchronization/ExternalWork
+
+        // MUST be ONE block
+        const auto workDivOneBlock = cms::alpakatools::make_workdiv<Acc1D>(1u, 1024u);
+        alpaka::enqueue(
+            queue,
+            alpaka::createTaskKernel<Acc1D>(
+                workDivOneBlock, ::pixelDetails::fillHitsModuleStart<pixelTopology::Phase1>(), clusters_d->view()));
+        // clusters_d->clusModuleStart()));
+
+        // last element holds the number of all clusters
+        const auto clusModuleStartLastElement = cms::alpakatools::make_device_view(
+            alpaka::getDev(queue),
+            const_cast<uint32_t const *>(clusters_d->view().clusModuleStart() + numberOfModules),
+            1u);
+        constexpr int startBPIX2 = pixelTopology::Phase1::layerStart[1];
+        // element startBPIX2 hold the number of clusters until BPIX2
+        const auto bpix2ClusterStart = cms::alpakatools::make_device_view(
+            alpaka::getDev(queue), const_cast<uint32_t const *>(clusters_d->view().clusModuleStart() + startBPIX2), 1u);
+        auto nModules_Clusters_h_1 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 1, 1u);
+        alpaka::memcpy(queue, nModules_Clusters_h_1, clusModuleStartLastElement);
+
+        auto nModules_Clusters_h_2 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 2, 1u);
+        alpaka::memcpy(queue, nModules_Clusters_h_2, bpix2ClusterStart);
+
+      }  // end clusterizer scope
+    }
+
+    void SiPixelRawToClusterKernel::makePhase2ClustersAsync(const SiPixelClusterThresholds clusterThresholds,
+                                                            SiPixelDigisLayoutSoAView &digis_view,
+                                                            const uint32_t numDigis,
+                                                            Queue &queue) {
+      using namespace pixelClustering;
+      using pixelTopology::Phase2;
+      nDigis = numDigis;
+      constexpr int numberOfModules = pixelTopology::Phase2::numberOfModules;
+      // digis_d = SiPixelDigisDevice(numDigis, queue);
+
+      // alpaka::memcpy(queue, digis_d->view(), digis_h_view);
+
+      clusters_d = SiPixelClustersDevice(Phase2::numberOfModules, queue);
+
+      // nModules_Clusters_h = cms::cuda::make_host_unique<uint32_t[]>(2, stream);
+
+      const auto threadsPerBlockOrElementsPerThread = 512;
+      const auto blocks =
+          cms::alpakatools::divide_up_by(std::max<int>(numDigis, numberOfModules), threadsPerBlockOrElementsPerThread);
+      const auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlockOrElementsPerThread);
+
+      // alpaka::enqueue(queue,
+      //                 alpaka::createTaskKernel<Acc1D>(
+      //                     workDiv, calibPixel::calibDigisPhase2{}, digis_view, clusters_d->view(), numDigis));
+
+#ifdef GPU_DEBUG
+      alpaka::wait(queue);
+      std::cout << "CUDA countModules kernel launch with " << blocks << " blocks of "
+                << threadsPerBlockOrElementsPerThread << " threadsPerBlockOrElementsPerThread\n";
+#endif
+      alpaka::enqueue(queue,
+                      alpaka::createTaskKernel<Acc1D>(
+                          workDiv, countModules<pixelTopology::Phase2>(), digis_view, clusters_d->view(), numDigis));
+
+      auto moduleStartFirstElement =
+          cms::alpakatools::make_device_view(alpaka::getDev(queue), clusters_d->view().moduleStart(), 1u);
+      alpaka::memcpy(queue, nModules_Clusters_h, moduleStartFirstElement);
+
+      const auto workDivMaxNumModules = cms::alpakatools::make_workdiv<Acc1D>(numberOfModules, 256);
+
+#ifdef GPU_DEBUG
+      alpaka::wait(queue);
+      std::cout << "CUDA findClus kernel launch with " << numberOfModules << " blocks of " << 256
+                << " threadsPerBlockOrElementsPerThread\n";
+#endif
+      alpaka::enqueue(
+          queue,
+          alpaka::createTaskKernel<Acc1D>(
+              workDivMaxNumModules, findClus<pixelTopology::Phase2>(), digis_view, clusters_d->view(), numDigis));
+#ifdef GPU_DEBUG
+      alpaka::wait(queue);
+#endif
+
+      // apply charge cut
+      alpaka::enqueue(queue,
+                      alpaka::createTaskKernel<Acc1D>(workDivMaxNumModules,
+                                                      ::pixelClustering::clusterChargeCut<pixelTopology::Phase2>(),
+                                                      digis_view,
+                                                      clusters_d->view(),
+                                                      clusterThresholds,
+                                                      numDigis));
+
+      // count the module start indices already here (instead of
+      // rechits) so that the number of clusters/hits can be made
+      // available in the rechit producer without additional points of
+      // synchronization/ExternalWork
+
+      // MUST be ONE block
+      const auto workDivOneBlock = cms::alpakatools::make_workdiv<Acc1D>(1u, 1024u);
+      alpaka::enqueue(
+          queue,
+          alpaka::createTaskKernel<Acc1D>(
+              workDivOneBlock, ::pixelDetails::fillHitsModuleStart<pixelTopology::Phase2>(), clusters_d->view()));
+      // clusters_d->clusModuleStart()));
+
+      // last element holds the number of all clusters
+      const auto clusModuleStartLastElement = cms::alpakatools::make_device_view(
+          alpaka::getDev(queue),
+          const_cast<uint32_t const *>(clusters_d->view().clusModuleStart() + numberOfModules),
+          1u);
+      constexpr int startBPIX2 = pixelTopology::Phase2::layerStart[1];
+      // element startBPIX2 hold the number of clusters until BPIX2
+      const auto bpix2ClusterStart = cms::alpakatools::make_device_view(
+          alpaka::getDev(queue), const_cast<uint32_t const *>(clusters_d->view().clusModuleStart() + startBPIX2), 1u);
+      auto nModules_Clusters_h_1 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 1, 1u);
+      alpaka::memcpy(queue, nModules_Clusters_h_1, clusModuleStartLastElement);
+
+      auto nModules_Clusters_h_2 = cms::alpakatools::make_host_view(nModules_Clusters_h.data() + 2, 1u);
+      alpaka::memcpy(queue, nModules_Clusters_h_2, bpix2ClusterStart);
+
+    }  //
+  }    // namespace pixelDetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -1,0 +1,199 @@
+#ifndef RecoLocalTracker_SiPixelClusterizer_SiPixelRawToClusterKernel_h
+#define RecoLocalTracker_SiPixelClusterizer_SiPixelRawToClusterKernel_h
+
+#include <algorithm>
+#include <optional>
+#include <utility>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsDevice.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+
+#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTDevice.h"
+#include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelMappingDevice.h"
+
+#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelFormatterErrors.h"
+#include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
+// struct SiPixelFedCablingMapGPU;
+// class SiPixelGainForHLTonGPU;
+
+namespace pixelDetails {
+
+  constexpr auto MAX_LINK = pixelgpudetails::MAX_LINK;
+  constexpr auto MAX_SIZE = pixelgpudetails::MAX_SIZE;
+  constexpr auto MAX_ROC = pixelgpudetails::MAX_ROC;
+  // Phase 1 geometry constants
+  const uint32_t layerStartBit = 20;
+  const uint32_t ladderStartBit = 12;
+  const uint32_t moduleStartBit = 2;
+
+  const uint32_t panelStartBit = 10;
+  const uint32_t diskStartBit = 18;
+  const uint32_t bladeStartBit = 12;
+
+  const uint32_t layerMask = 0xF;
+  const uint32_t ladderMask = 0xFF;
+  const uint32_t moduleMask = 0x3FF;
+  const uint32_t panelMask = 0x3;
+  const uint32_t diskMask = 0xF;
+  const uint32_t bladeMask = 0x3F;
+
+  const uint32_t LINK_bits = 6;
+  const uint32_t ROC_bits = 5;
+  const uint32_t DCOL_bits = 5;
+  const uint32_t PXID_bits = 8;
+  const uint32_t ADC_bits = 8;
+
+  // special for layer 1
+  const uint32_t LINK_bits_l1 = 6;
+  const uint32_t ROC_bits_l1 = 5;
+  const uint32_t COL_bits_l1 = 6;
+  const uint32_t ROW_bits_l1 = 7;
+  const uint32_t OMIT_ERR_bits = 1;
+
+  const uint32_t maxROCIndex = 8;
+  const uint32_t numRowsInRoc = 80;
+  const uint32_t numColsInRoc = 52;
+
+  const uint32_t MAX_WORD = 2000;
+
+  const uint32_t ADC_shift = 0;
+  const uint32_t PXID_shift = ADC_shift + ADC_bits;
+  const uint32_t DCOL_shift = PXID_shift + PXID_bits;
+  const uint32_t ROC_shift = DCOL_shift + DCOL_bits;
+  const uint32_t LINK_shift = ROC_shift + ROC_bits_l1;
+  // special for layer 1 ROC
+  const uint32_t ROW_shift = ADC_shift + ADC_bits;
+  const uint32_t COL_shift = ROW_shift + ROW_bits_l1;
+  const uint32_t OMIT_ERR_shift = 20;
+
+  const uint32_t LINK_mask = ~(~uint32_t(0) << LINK_bits_l1);
+  const uint32_t ROC_mask = ~(~uint32_t(0) << ROC_bits_l1);
+  const uint32_t COL_mask = ~(~uint32_t(0) << COL_bits_l1);
+  const uint32_t ROW_mask = ~(~uint32_t(0) << ROW_bits_l1);
+  const uint32_t DCOL_mask = ~(~uint32_t(0) << DCOL_bits);
+  const uint32_t PXID_mask = ~(~uint32_t(0) << PXID_bits);
+  const uint32_t ADC_mask = ~(~uint32_t(0) << ADC_bits);
+  const uint32_t ERROR_mask = ~(~uint32_t(0) << ROC_bits_l1);
+  const uint32_t OMIT_ERR_mask = ~(~uint32_t(0) << OMIT_ERR_bits);
+
+  struct DetIdGPU {
+    uint32_t RawId;
+    uint32_t rocInDet;
+    uint32_t moduleId;
+  };
+
+  struct Pixel {
+    uint32_t row;
+    uint32_t col;
+  };
+
+  ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr pixelchannelidentifierimpl::Packing packing() {
+    return PixelChannelIdentifier::thePacking;
+  }
+
+  ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr uint32_t pack(uint32_t row,
+                                                              uint32_t col,
+                                                              uint32_t adc,
+                                                              uint32_t flag = 0) {
+    constexpr pixelchannelidentifierimpl::Packing thePacking = packing();
+    adc = std::min(adc, uint32_t(thePacking.max_adc));
+
+    return (row << thePacking.row_shift) | (col << thePacking.column_shift) | (adc << thePacking.adc_shift);
+  }
+
+  constexpr uint32_t pixelToChannel(int row, int col) {
+    constexpr pixelchannelidentifierimpl::Packing thePacking = packing();
+    return (row << thePacking.column_width) | col;
+  }
+
+}  // namespace pixelDetails
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace pixelDetails {
+
+    class SiPixelRawToClusterKernel {
+    public:
+      class WordFedAppender {
+      public:
+        WordFedAppender();
+        ~WordFedAppender() = default;
+
+        WordFedAppender(uint32_t words);
+
+        void initializeWordFed(int fedId, unsigned int wordCounterGPU, const uint32_t* src, unsigned int length);
+
+        auto word() const { return word_; }
+        auto fedId() const { return fedId_; }
+
+      private:
+        cms::alpakatools::host_buffer<unsigned int[]> word_;
+        cms::alpakatools::host_buffer<unsigned char[]> fedId_;
+      };
+
+      SiPixelRawToClusterKernel() : nModules_Clusters_h{cms::alpakatools::make_host_buffer<uint32_t[], Platform>(3u)} {}
+
+      ~SiPixelRawToClusterKernel() = default;
+
+      SiPixelRawToClusterKernel(const SiPixelRawToClusterKernel&) = delete;
+      SiPixelRawToClusterKernel(SiPixelRawToClusterKernel&&) = delete;
+      SiPixelRawToClusterKernel& operator=(const SiPixelRawToClusterKernel&) = delete;
+      SiPixelRawToClusterKernel& operator=(SiPixelRawToClusterKernel&&) = delete;
+
+      void makeClustersAsync(bool isRun2,
+                             const SiPixelClusterThresholds clusterThresholds,
+                             const SiPixelMappingLayoutSoAConstView& cablingMap,
+                             const unsigned char* modToUnp,
+                             const SiPixelGainCalibrationForHLTSoAConstView& gains,
+                             const WordFedAppender& wordFed,
+                             SiPixelFormatterErrors&& errors,
+                             const uint32_t wordCounter,
+                             const uint32_t fedCounter,
+                             bool useQualityInfo,
+                             bool includeErrors,
+                             bool debug,
+                             Queue& queue);
+
+      void makePhase2ClustersAsync(const SiPixelClusterThresholds clusterThresholds,
+                                   SiPixelDigisLayoutSoAView& digis_view,
+                                   const uint32_t numDigis,
+                                   Queue& queue);
+
+      // std::pair<SiPixelDigisDevice, SiPixelClustersDevice> getResults() {
+      //   digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
+      //   clusters_d->setNClusters(nModules_Clusters_h[1], nModules_Clusters_h[2]);
+      //   return std::make_pair(std::move(*digis_d), std::move(*clusters_d));
+      // }
+
+      SiPixelDigisDevice&& getDigis() {
+        digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
+        return std::move(*digis_d);
+      }
+
+      SiPixelClustersDevice&& getClusters() {
+        clusters_d->setNClusters(nModules_Clusters_h[1], nModules_Clusters_h[2]);
+        return std::move(*clusters_d);
+      }
+
+      SiPixelDigiErrorsDevice&& getErrors() { return std::move(*digiErrors_d); }
+
+    private:
+      uint32_t nDigis = 0;
+
+      // Data to be put in the event
+      cms::alpakatools::host_buffer<uint32_t[]> nModules_Clusters_h;
+      std::optional<SiPixelDigisDevice> digis_d;
+      std::optional<SiPixelClustersDevice> clusters_d;
+      std::optional<SiPixelDigiErrorsDevice> digiErrors_d;
+    };
+
+  }  // namespace pixelDetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // plugin_SiPixelClusterizer_alpaka_SiPixelRawToClusterKernel_h

--- a/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
@@ -13,7 +13,6 @@
 <use name="CUDADataFormats/BeamSpot"/>
 <use name="FWCore/ParameterSet"/>
 <use name="HeterogeneousCore/AlpakaCore"/>
-<use name="HeterogeneousCore/AlpakaUtilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>

--- a/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/BuildFile.xml
@@ -1,15 +1,23 @@
 <use name="boost"/>
 <use name="boost_regex"/>
 <use name="cuda"/>
+<use name="alpaka"/>
 <use name="vdt_headers"/>
 <use name="CondFormats/SiPixelObjects"/>
 <use name="CondFormats/SiPixelTransient"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackingRecHitSoA"/>
+<use name="DataFormats/BeamSpotAlpaka"/>
+<use name="CUDADataFormats/TrackingRecHit"/>
+<use name="CUDADataFormats/BeamSpot"/>
 <use name="FWCore/ParameterSet"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaUtilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastAlpaka.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastAlpaka.h
@@ -1,0 +1,51 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_PixelCPEFastAlpaka_h
+#define RecoLocalTracker_SiPixelRecHits_PixelCPEFastAlpaka_h
+
+#include <utility>
+
+#include "CondFormats/SiPixelTransient/interface/SiPixelGenError.h"
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericBase.h"
+// #include "RecoLocalTracker/SiPixelRecHits/interface/alpaka/pixelCPEforGPU.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+class MagneticField;
+template <typename TrackerTraits>
+class PixelCPEFastAlpaka final : public PixelCPEGenericBase {
+public:
+  PixelCPEFastAlpaka(edm::ParameterSet const &conf,
+                     const MagneticField *,
+                     const TrackerGeometry &,
+                     const TrackerTopology &,
+                     const SiPixelLorentzAngle *,
+                     const SiPixelGenErrorDBObject *,
+                     const SiPixelLorentzAngle *);
+
+  ~PixelCPEFastAlpaka() override = default;
+
+  static void fillPSetDescription(edm::ParameterSetDescription &desc);
+
+  // The return value can only be used safely in kernels launched on
+  // the same cudaStream, or after cudaStreamSynchronize.
+  using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
+  using LayerGeometry = pixelCPEforDevice::LayerGeometryT<TrackerTraits>;
+  using AverageGeometry = pixelTopology::AverageGeometryT<TrackerTraits>;
+
+  ParamsOnDevice const &getCPEFastParams() const { return cpeParams_; }
+
+private:
+  LocalPoint localPosition(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
+  LocalError localError(DetParam const &theDetParam, ClusterParam &theClusterParam) const override;
+
+  void errorFromTemplates(DetParam const &theDetParam, ClusterParamGeneric &theClusterParam, float qclus) const;
+
+  //--- DB Error Parametrization object, new light templates
+  std::vector<SiPixelGenErrorStore> thePixelGenError_;
+  ParamsOnDevice cpeParams_;
+
+  void initializeParams();
+};
+
+#endif  // RecoLocalTracker_SiPixelRecHits_PixelCPEFastAlpaka_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h
@@ -1,0 +1,181 @@
+#ifndef DataFormats_PixelCPEFastParams_interface_PixelCPEFastParams_h
+#define DataFormats_PixelCPEFastParams_interface_PixelCPEFastParams_h
+
+#include <alpaka/alpaka.hpp>
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "DataFormats/GeometrySurface/interface/SOARotation.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h"
+
+// Nesting this namespace to prevent conflicts with pixelCPEForDevice.h
+namespace CPEFastParametrisation {
+  // From https://cmssdt.cern.ch/dxr/CMSSW/source/CondFormats/SiPixelTransient/src/SiPixelGenError.cc#485-486
+  // qbin: int (0-4) describing the charge of the cluster
+  // [0: 1.5<Q/Qavg, 1: 1<Q/Qavg<1.5, 2: 0.85<Q/Qavg<1, 3: 0.95Qmin<Q<0.85Qavg, 4: Q<0.95Qmin]
+  constexpr int kGenErrorQBins = 5;
+  // arbitrary number of bins for sampling errors
+  constexpr int kNumErrorBins = 16;
+}  // namespace CPEFastParametrisation
+
+// Mostly similar to pixelCPEforDevice namespace,
+// to prevent conflicts until we completely replace it.
+// See pixelCPEForDevice.h.
+namespace pixelCPEforDevice {
+
+  using Status = SiPixelHitStatus;
+  using Frame = SOAFrame<float>;
+  using Rotation = SOARotation<float>;
+
+  // SOA (on device)
+
+  template <uint32_t N>
+  struct ClusParamsT {
+    uint32_t minRow[N];
+    uint32_t maxRow[N];
+    uint32_t minCol[N];
+    uint32_t maxCol[N];
+
+    int32_t q_f_X[N];
+    int32_t q_l_X[N];
+    int32_t q_f_Y[N];
+    int32_t q_l_Y[N];
+
+    int32_t charge[N];
+
+    float xpos[N];
+    float ypos[N];
+
+    float xerr[N];
+    float yerr[N];
+
+    int16_t xsize[N];  // (*8) clipped at 127 if negative is edge....
+    int16_t ysize[N];
+
+    Status status[N];
+  };
+
+  // all modules are identical!
+  struct CommonParams {
+    float theThicknessB;
+    float theThicknessE;
+    float thePitchX;
+    float thePitchY;
+
+    uint16_t maxModuleStride;
+    uint8_t numberOfLaddersInBarrel;
+  };
+
+  struct DetParams {
+    bool isBarrel;
+    bool isPosZ;
+    uint16_t layer;
+    uint16_t index;
+    uint32_t rawId;
+
+    float shiftX;
+    float shiftY;
+    float chargeWidthX;
+    float chargeWidthY;
+    uint16_t pixmx;  // max pix charge
+
+    uint16_t nRowsRoc;  //we don't need 2^16 columns, is worth to use 15 + 1 for sign
+    uint16_t nColsRoc;
+    uint16_t nRows;
+    uint16_t nCols;
+
+    uint32_t numPixsInModule;
+
+    float x0, y0, z0;  // the vertex in the local coord of the detector
+
+    float apeXX, apeYY;  // ape^2
+    uint8_t sx2, sy1, sy2;
+    uint8_t sigmax[CPEFastParametrisation::kNumErrorBins], sigmax1[CPEFastParametrisation::kNumErrorBins],
+        sigmay[CPEFastParametrisation::kNumErrorBins];  // in micron
+    float xfact[CPEFastParametrisation::kGenErrorQBins], yfact[CPEFastParametrisation::kGenErrorQBins];
+    int minCh[CPEFastParametrisation::kGenErrorQBins];
+
+    Frame frame;
+  };
+
+  template <typename TrackerTopology>
+  struct LayerGeometryT {
+    uint32_t layerStart[TrackerTopology::numberOfLayers + 1];
+    uint8_t layer[pixelTopology::layerIndexSize<TrackerTopology>];
+    uint16_t maxModuleStride;
+  };
+
+  // ES Product to be used by RecHit generation
+  template <typename TrackerTopology>
+  struct ParamsOnDeviceT {
+    using LayerGeometry = LayerGeometryT<TrackerTopology>;
+    using AverageGeometry = pixelTopology::AverageGeometryT<TrackerTopology>;
+
+    CommonParams m_commonParams;
+    // Will contain an array of DetParams instances
+    DetParams m_detParams[1440];
+    LayerGeometry m_layerGeometry;
+    AverageGeometry m_averageGeometry;
+
+    constexpr CommonParams const& __restrict__ commonParams() const { return m_commonParams; }
+    constexpr DetParams const& __restrict__ detParams(int i) const { return m_detParams[i]; }
+    constexpr LayerGeometry const& __restrict__ layerGeometry() const { return m_layerGeometry; }
+    constexpr AverageGeometry const& __restrict__ averageGeometry() const { return m_averageGeometry; }
+
+    ALPAKA_FN_ACC uint8_t layer(uint16_t id) const {
+      return m_layerGeometry.layer[id / TrackerTopology::maxModuleStride];
+    };
+  };
+
+  template <typename TDev, typename TrackerTraits>
+  class PixelCPEFastParams {
+  public:
+    using Buffer = cms::alpakatools::device_buffer<TDev, ParamsOnDeviceT<TrackerTraits>>;
+    using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, ParamsOnDeviceT<TrackerTraits>>;
+
+    explicit PixelCPEFastParams(Buffer buffer) : buffer_(std::move(buffer)) {}
+
+    Buffer buffer() { return buffer_; }
+    ConstBuffer buffer() const { return buffer_; }
+    ConstBuffer const_buffer() const { return buffer_; }
+    ParamsOnDeviceT<TrackerTraits> const* data() const { return buffer_.data(); }
+    auto size() const { return alpaka::getExtentProduct(buffer_); }
+
+  private:
+    Buffer buffer_;
+  };
+
+}  // namespace pixelCPEforDevice
+
+namespace cms::alpakatools {
+  template <>
+  struct CopyToDevice<pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase1>> {
+    template <typename TQueue>
+    static auto copyAsync(
+        TQueue& queue, pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase1> hostData) {
+      using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::Phase1>;
+      auto deviceData =
+          cms::alpakatools::make_device_buffer<pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::Phase1>>(queue);
+      alpaka::memcpy(queue, deviceData, hostData.buffer());
+      return deviceData;
+    }
+  };
+
+  template <>
+  struct CopyToDevice<pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase2>> {
+    template <typename TQueue>
+    static auto copyAsync(
+        TQueue& queue, pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase2> hostData) {
+      using ParamsOnDevice = pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::Phase1>;
+      auto deviceData =
+          cms::alpakatools::make_device_buffer<pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::Phase2>>(queue);
+      alpaka::memcpy(queue, deviceData, hostData.buffer());
+      return deviceData;
+    }
+  };
+
+}  // namespace cms::alpakatools
+
+#endif

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h
@@ -149,6 +149,9 @@ namespace pixelCPEforDevice {
 
 }  // namespace pixelCPEforDevice
 
+// The following are manual implementations of methods for asynchronously creating a copy of the Phase 1&2 CPEFastParams
+// objects created on the the device to the host. The copyAsync() method is automatically called on produce() or consume()
+// calls. Data structures inheriting from portableHostCollection do not need to implement such methods manually. 
 namespace cms::alpakatools {
   template <>
   struct CopyToDevice<pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase1>> {

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -1,0 +1,314 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_interface_pixelCPEforDevice_h
+#define RecoLocalTracker_SiPixelRecHits_interface_pixelCPEforDevice_h
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+
+namespace pixelCPEforDevice {
+
+  constexpr int32_t MaxHitsInIter = pixelClustering::maxHitsInIter();
+  using ClusParams = ClusParamsT<MaxHitsInIter>;
+
+  constexpr inline void computeAnglesFromDet(
+      DetParams const& __restrict__ detParams, float const x, float const y, float& cotalpha, float& cotbeta) {
+    // x,y local position on det
+    auto gvx = x - detParams.x0;
+    auto gvy = y - detParams.y0;
+    auto gvz = -1.f / detParams.z0;
+    // normalization not required as only ratio used...
+    // calculate angles
+    cotalpha = gvx * gvz;
+    cotbeta = gvy * gvz;
+  }
+
+  constexpr inline float correction(int sizeM1,
+                                    int q_f,                        //!< Charge in the first pixel.
+                                    int q_l,                        //!< Charge in the last pixel.
+                                    uint16_t upper_edge_first_pix,  //!< As the name says.
+                                    uint16_t lower_edge_last_pix,   //!< As the name says.
+                                    float lorentz_shift,            //!< L-shift at half thickness
+                                    float theThickness,             //detector thickness
+                                    float cot_angle,                //!< cot of alpha_ or beta_
+                                    float pitch,                    //!< thePitchX or thePitchY
+                                    bool first_is_big,              //!< true if the first is big
+                                    bool last_is_big)               //!< true if the last is big
+  {
+    if (0 == sizeM1)  // size 1
+      return 0;
+
+    float w_eff = 0;
+    bool simple = true;
+    if (1 == sizeM1) {  // size 2
+      //--- Width of the clusters minus the edge (first and last) pixels.
+      //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
+      // assert(lower_edge_last_pix >= upper_edge_first_pix);
+      auto w_inner = pitch * float(lower_edge_last_pix - upper_edge_first_pix);  // in cm
+
+      //--- Predicted charge width from geometry
+      auto w_pred = theThickness * cot_angle  // geometric correction (in cm)
+                    - lorentz_shift;          // (in cm) &&& check fpix!
+
+      w_eff = std::abs(w_pred) - w_inner;
+
+      //--- If the observed charge width is inconsistent with the expectations
+      //--- based on the track, do *not* use w_pred-w_inner.  Instead, replace
+      //--- it with an *average* effective charge width, which is the average
+      //--- length of the edge pixels.
+
+      // this can produce "large" regressions for very small numeric differences
+      simple = (w_eff < 0.0f) | (w_eff > pitch);
+    }
+
+    if (simple) {
+      //--- Total length of the two edge pixels (first+last)
+      float sum_of_edge = 2.0f;
+      if (first_is_big)
+        sum_of_edge += 1.0f;
+      if (last_is_big)
+        sum_of_edge += 1.0f;
+      w_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+    }
+
+    //--- Finally, compute the position in this projection
+    float qdiff = q_l - q_f;
+    float qsum = q_l + q_f;
+
+    //--- Temporary fix for clusters with both first and last pixel with charge = 0
+    if (qsum == 0)
+      qsum = 1.0f;
+
+    return 0.5f * (qdiff / qsum) * w_eff;
+  }
+
+  template <typename TrackerTraits>
+  constexpr inline void position(CommonParams const& __restrict__ comParams,
+                                 DetParams const& __restrict__ detParams,
+                                 ClusParams& cp,
+                                 uint32_t ic) {
+    constexpr int maxSize = TrackerTraits::maxSizeCluster;
+    //--- Upper Right corner of Lower Left pixel -- in measurement frame
+    uint16_t llx = cp.minRow[ic] + 1;
+    uint16_t lly = cp.minCol[ic] + 1;
+
+    //--- Lower Left corner of Upper Right pixel -- in measurement frame
+    uint16_t urx = cp.maxRow[ic];
+    uint16_t ury = cp.maxCol[ic];
+
+    uint16_t llxl = llx, llyl = lly, urxl = urx, uryl = ury;
+
+    llxl = TrackerTraits::localX(llx);
+    llyl = TrackerTraits::localY(lly);
+    urxl = TrackerTraits::localX(urx);
+    uryl = TrackerTraits::localY(ury);
+
+    auto mx = llxl + urxl;
+    auto my = llyl + uryl;
+
+    int xsize = int(urxl) + 2 - int(llxl);
+    int ysize = int(uryl) + 2 - int(llyl);
+    assert(xsize >= 0);  // 0 if bixpix...
+    assert(ysize >= 0);
+
+    if (TrackerTraits::isBigPixX(cp.minRow[ic]))
+      ++xsize;
+    if (TrackerTraits::isBigPixX(cp.maxRow[ic]))
+      ++xsize;
+    if (TrackerTraits::isBigPixY(cp.minCol[ic]))
+      ++ysize;
+    if (TrackerTraits::isBigPixY(cp.maxCol[ic]))
+      ++ysize;
+
+    int unbalanceX = 8.f * std::abs(float(cp.q_f_X[ic] - cp.q_l_X[ic])) / float(cp.q_f_X[ic] + cp.q_l_X[ic]);
+    int unbalanceY = 8.f * std::abs(float(cp.q_f_Y[ic] - cp.q_l_Y[ic])) / float(cp.q_f_Y[ic] + cp.q_l_Y[ic]);
+
+    xsize = 8 * xsize - unbalanceX;
+    ysize = 8 * ysize - unbalanceY;
+
+    cp.xsize[ic] = std::min(xsize, maxSize);
+    cp.ysize[ic] = std::min(ysize, maxSize);
+
+    if (cp.minRow[ic] == 0 || cp.maxRow[ic] == uint32_t(detParams.nRows - 1))
+      cp.xsize[ic] = -cp.xsize[ic];
+
+    if (cp.minCol[ic] == 0 || cp.maxCol[ic] == uint32_t(detParams.nCols - 1))
+      cp.ysize[ic] = -cp.ysize[ic];
+
+    // apply the lorentz offset correction
+    float xoff = 0.5f * float(detParams.nRows) * comParams.thePitchX;
+    float yoff = 0.5f * float(detParams.nCols) * comParams.thePitchY;
+
+    //correction for bigpixels for phase1
+    xoff = xoff + TrackerTraits::bigPixXCorrection * comParams.thePitchX;
+    yoff = yoff + TrackerTraits::bigPixYCorrection * comParams.thePitchY;
+
+    // apply the lorentz offset correction
+    auto xPos = detParams.shiftX + (comParams.thePitchX * 0.5f * float(mx)) - xoff;
+    auto yPos = detParams.shiftY + (comParams.thePitchY * 0.5f * float(my)) - yoff;
+
+    float cotalpha = 0, cotbeta = 0;
+
+    computeAnglesFromDet(detParams, xPos, yPos, cotalpha, cotbeta);
+
+    auto thickness = detParams.isBarrel ? comParams.theThicknessB : comParams.theThicknessE;
+
+    auto xcorr = correction(cp.maxRow[ic] - cp.minRow[ic],
+                            cp.q_f_X[ic],
+                            cp.q_l_X[ic],
+                            llxl,
+                            urxl,
+                            detParams.chargeWidthX,  // lorentz shift in cm
+                            thickness,
+                            cotalpha,
+                            comParams.thePitchX,
+                            TrackerTraits::isBigPixX(cp.minRow[ic]),
+                            TrackerTraits::isBigPixX(cp.maxRow[ic]));
+
+    auto ycorr = correction(cp.maxCol[ic] - cp.minCol[ic],
+                            cp.q_f_Y[ic],
+                            cp.q_l_Y[ic],
+                            llyl,
+                            uryl,
+                            detParams.chargeWidthY,  // lorentz shift in cm
+                            thickness,
+                            cotbeta,
+                            comParams.thePitchY,
+                            TrackerTraits::isBigPixY(cp.minCol[ic]),
+                            TrackerTraits::isBigPixY(cp.maxCol[ic]));
+
+    cp.xpos[ic] = xPos + xcorr;
+    cp.ypos[ic] = yPos + ycorr;
+  }
+
+  template <typename TrackerTraits>
+  constexpr inline void errorFromSize(CommonParams const& __restrict__ comParams,
+                                      DetParams const& __restrict__ detParams,
+                                      ClusParams& cp,
+                                      uint32_t ic) {
+    // Edge cluster errors
+    cp.xerr[ic] = 0.0050;
+    cp.yerr[ic] = 0.0085;
+
+    // FIXME these are errors form Run1
+    float xerr_barrel_l1_def = TrackerTraits::xerr_barrel_l1_def;
+    float yerr_barrel_l1_def = TrackerTraits::yerr_barrel_l1_def;
+    float xerr_barrel_ln_def = TrackerTraits::xerr_barrel_ln_def;
+    float yerr_barrel_ln_def = TrackerTraits::yerr_barrel_ln_def;
+    float xerr_endcap_def = TrackerTraits::xerr_endcap_def;
+    float yerr_endcap_def = TrackerTraits::yerr_endcap_def;
+
+    constexpr float xerr_barrel_l1[] = {0.00115, 0.00120, 0.00088};  //TODO MOVE THESE SOMEWHERE ELSE
+    constexpr float yerr_barrel_l1[] = {
+        0.00375, 0.00230, 0.00250, 0.00250, 0.00230, 0.00230, 0.00210, 0.00210, 0.00240};
+    constexpr float xerr_barrel_ln[] = {0.00115, 0.00120, 0.00088};
+    constexpr float yerr_barrel_ln[] = {
+        0.00375, 0.00230, 0.00250, 0.00250, 0.00230, 0.00230, 0.00210, 0.00210, 0.00240};
+    constexpr float xerr_endcap[] = {0.0020, 0.0020};
+    constexpr float yerr_endcap[] = {0.00210};
+
+    auto sx = cp.maxRow[ic] - cp.minRow[ic];
+    auto sy = cp.maxCol[ic] - cp.minCol[ic];
+
+    // is edgy ?
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
+
+    // is one and big?
+    bool isBig1X = ((0 == sx) && TrackerTraits::isBigPixX(cp.minRow[ic]));
+    bool isBig1Y = ((0 == sy) && TrackerTraits::isBigPixY(cp.minCol[ic]));
+
+    if (!isEdgeX && !isBig1X) {
+      if (not detParams.isBarrel) {
+        cp.xerr[ic] = sx < std::size(xerr_endcap) ? xerr_endcap[sx] : xerr_endcap_def;
+      } else if (detParams.layer == 1) {
+        cp.xerr[ic] = sx < std::size(xerr_barrel_l1) ? xerr_barrel_l1[sx] : xerr_barrel_l1_def;
+      } else {
+        cp.xerr[ic] = sx < std::size(xerr_barrel_ln) ? xerr_barrel_ln[sx] : xerr_barrel_ln_def;
+      }
+    }
+
+    if (!isEdgeY && !isBig1Y) {
+      if (not detParams.isBarrel) {
+        cp.yerr[ic] = sy < std::size(yerr_endcap) ? yerr_endcap[sy] : yerr_endcap_def;
+      } else if (detParams.layer == 1) {
+        cp.yerr[ic] = sy < std::size(yerr_barrel_l1) ? yerr_barrel_l1[sy] : yerr_barrel_l1_def;
+      } else {
+        cp.yerr[ic] = sy < std::size(yerr_barrel_ln) ? yerr_barrel_ln[sy] : yerr_barrel_ln_def;
+      }
+    }
+  }
+
+  template <typename TrackerTraits>
+  constexpr inline void errorFromDB(CommonParams const& __restrict__ comParams,
+                                    DetParams const& __restrict__ detParams,
+                                    ClusParams& cp,
+                                    uint32_t ic) {
+    // Edge cluster errors
+    cp.xerr[ic] = 0.0050f;
+    cp.yerr[ic] = 0.0085f;
+
+    auto sx = cp.maxRow[ic] - cp.minRow[ic];
+    auto sy = cp.maxCol[ic] - cp.minCol[ic];
+
+    // is edgy ?  (size is set negative: see above)
+    bool isEdgeX = cp.xsize[ic] < 1;
+    bool isEdgeY = cp.ysize[ic] < 1;
+    // is one and big?
+    bool isOneX = (0 == sx);
+    bool isOneY = (0 == sy);
+    bool isBigX = TrackerTraits::isBigPixX(cp.minRow[ic]);
+    bool isBigY = TrackerTraits::isBigPixY(cp.minCol[ic]);
+
+    auto ch = cp.charge[ic];
+    auto bin = 0;
+    for (; bin < CPEFastParametrisation::kGenErrorQBins - 1; ++bin)
+      // find first bin which minimum charge exceeds cluster charge
+      if (ch < detParams.minCh[bin + 1])
+        break;
+
+    // in detParams qBins are reversed bin0 -> smallest charge, bin4-> largest charge
+    // whereas in CondFormats/SiPixelTransient/src/SiPixelGenError.cc it is the opposite
+    // so we reverse the bin here -> kGenErrorQBins - 1 - bin
+    cp.status[ic].qBin = CPEFastParametrisation::kGenErrorQBins - 1 - bin;
+    cp.status[ic].isOneX = isOneX;
+    cp.status[ic].isBigX = (isOneX & isBigX) | isEdgeX;
+    cp.status[ic].isOneY = isOneY;
+    cp.status[ic].isBigY = (isOneY & isBigY) | isEdgeY;
+
+    auto xoff = -float(TrackerTraits::xOffset) * comParams.thePitchX;
+    int low_value = 0;
+    int high_value = CPEFastParametrisation::kNumErrorBins - 1;
+    int bin_value = float(CPEFastParametrisation::kNumErrorBins) * (cp.xpos[ic] + xoff) / (2 * xoff);
+    // return estimated bin value truncated to [0, 15]
+    int jx = std::clamp(bin_value, low_value, high_value);
+
+    auto toCM = [](uint8_t x) { return float(x) * 1.e-4f; };
+
+    if (not isEdgeX) {
+      cp.xerr[ic] = isOneX ? toCM(isBigX ? detParams.sx2 : detParams.sigmax1[jx])
+                           : detParams.xfact[bin] * toCM(detParams.sigmax[jx]);
+    }
+
+    auto ey = cp.ysize[ic] > 8 ? detParams.sigmay[std::min(cp.ysize[ic] - 9, 15)] : detParams.sy1;
+    if (not isEdgeY) {
+      cp.yerr[ic] = isOneY ? toCM(isBigY ? detParams.sy2 : detParams.sy1) : detParams.yfact[bin] * toCM(ey);
+    }
+  }
+
+  //for Phase2 -> fallback to error from size
+  template <>
+  constexpr inline void errorFromDB<pixelTopology::Phase2>(CommonParams const& __restrict__ comParams,
+                                                           DetParams const& __restrict__ detParams,
+                                                           ClusParams& cp,
+                                                           uint32_t ic) {
+    errorFromSize<pixelTopology::Phase2>(comParams, detParams, cp, ic);
+  }
+
+}  // namespace pixelCPEforDevice
+
+#endif  // RecoLocalTracker_SiPixelRecHits_interface_pixelCPEforDevice_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -12,6 +12,13 @@
 
 namespace pixelCPEforDevice {
 
+  /**
+   * \namespace pixelCPEforDevice
+   *
+   * \brief Contains functions which are used to estimate the position of a given RecHit (cluster)
+   *
+   */ 
+
   constexpr int32_t MaxHitsInIter = pixelClustering::maxHitsInIter();
   using ClusParams = ClusParamsT<MaxHitsInIter>;
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/TrackerCommon"/>
 <use name="HeterogeneousCore/AlpakaCore"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
-<use name="HeterogeneousCore/AlpakaUtilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>
 <use name="RecoLocalTracker/Records"/>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -1,11 +1,16 @@
 <use name="fmt"/>
-<use name="CUDADataFormats/BeamSpot"/>
-<use name="CUDADataFormats/TrackingRecHit"/>
+<use name="DataFormats/BeamSpotAlpaka"/>
+<use name="DataFormats/TrackingRecHitSoA"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousCore/AlpakaUtilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="RecoLocalTracker/ClusterParameterEstimator"/>
 <use name="RecoLocalTracker/Records"/>
 <use name="RecoLocalTracker/SiPixelRecHits"/>
-<use name="DataFormats/TrackerCommon"/>
+<use name="CUDADataFormats/BeamSpot"/>
+<use name="CUDADataFormats/TrackingRecHit"/>
 <iftool name="cuda-gcc-support">
   <use name="cuda"/>
   <set name="cuda_src" value="*.cu"/>
@@ -13,5 +18,11 @@
   <set name="cuda_src" value=""/>
 </iftool>
 <library file="*.cc ${cuda_src}" name="RecoLocalTrackerSiPixelRecHitsPlugins">
+  <flags EDM_PLUGIN="1"/>
+</library>
+<library file="alpaka/*.cc" name="RecoLocalTrackerSiPixelRecHitsPluginsPortable">
+  <use name="alpaka"/>
+  <use name="DataFormats/Portable"/>
+  <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -1,0 +1,195 @@
+#include <alpaka/alpaka.hpp>
+
+#include <fmt/printf.h>
+
+#include "DataFormats/Portable/interface/HostProductAlpaka.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+
+template <typename TrackerTraits>
+class SiPixelRecHitFromSoAAlpaka : public edm::global::EDProducer<> {
+  using HitModuleStartArray = typename TrackingRecHitAlpakaSoA<TrackerTraits>::HitModuleStartArray;
+  using hindex_type = typename TrackerTraits::hindex_type;
+
+public:
+  explicit SiPixelRecHitFromSoAAlpaka(const edm::ParameterSet& iConfig);
+  ~SiPixelRecHitFromSoAAlpaka() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  using HMSstorage = HostProductAlpaka<uint32_t[]>;
+
+  // Data has been implicitly copied from Device to Host by the framework
+  using HitsOnHost = TrackingRecHitAlpakaHost<TrackerTraits>;
+
+private:
+  void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::EDGetTokenT<HitsOnHost> hitsToken_;                      // Alpaka hits
+  const edm::EDGetTokenT<SiPixelClusterCollectionNew> clusterToken_;  // legacy clusters
+  const edm::EDPutTokenT<SiPixelRecHitCollection> rechitsPutToken_;   // legacy rechits
+  const edm::EDPutTokenT<HMSstorage> hostPutToken_;
+};
+
+template <typename TrackerTraits>
+SiPixelRecHitFromSoAAlpaka<TrackerTraits>::SiPixelRecHitFromSoAAlpaka(const edm::ParameterSet& iConfig)
+    : geomToken_(esConsumes()),
+      hitsToken_(consumes(iConfig.getParameter<edm::InputTag>("pixelRecHitSrc"))),
+      clusterToken_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+      rechitsPutToken_(produces()),
+      hostPutToken_(produces()) {}
+
+template <typename TrackerTraits>
+void SiPixelRecHitFromSoAAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pixelRecHitSrc", edm::InputTag("siPixelRecHitsPreSplittingAlpaka"));
+  desc.add<edm::InputTag>("src", edm::InputTag("siPixelClustersPreSplitting"));
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename TrackerTraits>
+void SiPixelRecHitFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID streamID,
+                                                        edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup) const {
+  auto& hits_h_ = iEvent.get(hitsToken_);
+  auto nHits = hits_h_.view().nHits();
+  LogDebug("SiPixelRecHitFromSoAAlpaka") << "converting " << nHits << " Hits";
+
+  // allocate a buffer for the indices of the clusters
+  constexpr auto nMaxModules = TrackerTraits::numberOfModules;
+  auto hmsp = cms::alpakatools::make_host_buffer<hindex_type[]>(nMaxModules + 1);
+
+  SiPixelRecHitCollection output;
+  output.reserve(nMaxModules, nHits);
+
+  if (0 == nHits) {
+    iEvent.emplace(rechitsPutToken_, std::move(output));
+    iEvent.emplace(hostPutToken_, std::move(hmsp));
+    return;
+  }
+  output.reserve(nMaxModules, nHits);
+
+  // Could not make a view on hitsModuleStart
+  //alpaka::memcpy(iEvent.queue(), hmsp, hitsModuleStartView);
+
+  // std::copy not really working, cannot d
+  //std::copy(hits_h_.view().hitsModuleStart(), &hits_h_.view().hitsModuleStart() + nMaxModules + 1, hmsp.data());
+  std::memcpy((void*)hmsp.data(), (void*)&hits_h_.view().hitsModuleStart(), sizeof(HitModuleStartArray));
+
+  // wrap the buffer in a HostProduct, and move it to the Event, without reallocating the buffer or affecting hitsModuleStart
+  iEvent.emplace(hostPutToken_, std::move(hmsp));
+
+  auto xl = hits_h_.view().xLocal();
+  auto yl = hits_h_.view().yLocal();
+  auto xe = hits_h_.view().xerrLocal();
+  auto ye = hits_h_.view().yerrLocal();
+
+  const TrackerGeometry* geom = &iSetup.getData(geomToken_);
+
+  edm::Handle<SiPixelClusterCollectionNew> hclusters = iEvent.getHandle(clusterToken_);
+  auto const& input = *hclusters;
+
+  constexpr uint32_t maxHitsInModule = pixelClustering::maxHitsInModule();
+
+  int numberOfDetUnits = 0;
+  int numberOfClusters = 0;
+  for (auto const& dsv : input) {
+    numberOfDetUnits++;
+    unsigned int detid = dsv.detId();
+    DetId detIdObject(detid);
+    const GeomDetUnit* genericDet = geom->idToDetUnit(detIdObject);
+    auto gind = genericDet->index();
+    const PixelGeomDetUnit* pixDet = dynamic_cast<const PixelGeomDetUnit*>(genericDet);
+    assert(pixDet);
+    SiPixelRecHitCollection::FastFiller recHitsOnDetUnit(output, detid);
+    auto fc = hits_h_.view().hitsModuleStart()[gind];
+    auto lc = hits_h_.view().hitsModuleStart()[gind + 1];
+    auto nhits = lc - fc;
+
+    assert(lc > fc);
+    LogDebug("SiPixelRecHitFromSoAAlpaka") << "in det " << gind << ": conv " << nhits << " hits from " << dsv.size()
+                                           << " legacy clusters" << ' ' << fc << ',' << lc << "\n";
+    if (nhits > maxHitsInModule)
+      edm::LogWarning("SiPixelRecHitFromSoAAlpaka") << fmt::sprintf(
+          "Too many clusters %d in module %d. Only the first %d hits will be converted", nhits, gind, maxHitsInModule);
+    nhits = std::min(nhits, maxHitsInModule);
+
+    LogDebug("SiPixelRecHitFromSoAAlpaka") << "in det " << gind << "conv " << nhits << " hits from " << dsv.size()
+                                           << " legacy clusters" << ' ' << lc << ',' << fc;
+
+    if (0 == nhits)
+      continue;
+    auto jnd = [&](int k) { return fc + k; };
+    assert(nhits <= dsv.size());
+    if (nhits != dsv.size()) {
+      edm::LogWarning("GPUHits2CPU") << "nhits!= nclus " << nhits << ' ' << dsv.size();
+    }
+    for (auto const& clust : dsv) {
+      assert(clust.originalId() >= 0);
+      assert(clust.originalId() < dsv.size());
+      if (clust.originalId() >= nhits)
+        continue;
+      auto ij = jnd(clust.originalId());
+      LocalPoint lp(xl[ij], yl[ij]);
+      LocalError le(xe[ij], 0, ye[ij]);
+      SiPixelRecHitQuality::QualWordType rqw = 0;
+
+      numberOfClusters++;
+
+      /* cpu version....  (for reference)
+    std::tuple<LocalPoint, LocalError, SiPixelRecHitQuality::QualWordType> tuple = cpe_->getParameters( clust, *genericDet );
+    LocalPoint lp( std::get<0>(tuple) );
+    LocalError le( std::get<1>(tuple) );
+    SiPixelRecHitQuality::QualWordType rqw( std::get<2>(tuple) );
+    */
+
+      // Create a persistent edm::Ref to the cluster
+      edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> cluster = edmNew::makeRefTo(hclusters, &clust);
+      // Make a RecHit and add it to the DetSet
+      recHitsOnDetUnit.emplace_back(lp, le, rqw, *genericDet, cluster);
+      // =============================
+
+      LogDebug("SiPixelRecHitFromSoAAlpaka") << "cluster " << numberOfClusters << " at " << lp << ' ' << le;
+
+    }  //  <-- End loop on Clusters
+
+    //  LogDebug("SiPixelRecHitGPU")
+    LogDebug("SiPixelRecHitFromSoAAlpaka") << "found " << recHitsOnDetUnit.size() << " RecHits on " << detid;
+
+  }  //    <-- End loop on DetUnits
+
+  LogDebug("SiPixelRecHitFromSoAAlpaka") << "found " << numberOfDetUnits << " dets, " << numberOfClusters
+                                         << " clusters";
+
+  iEvent.emplace(rechitsPutToken_, std::move(output));
+}
+
+using SiPixelRecHitFromSoAAlpakaPhase1 = SiPixelRecHitFromSoAAlpaka<pixelTopology::Phase1>;
+DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpakaPhase1);
+
+using SiPixelRecHitFromSoAAlpakaPhase2 = SiPixelRecHitFromSoAAlpaka<pixelTopology::Phase2>;
+DEFINE_FWK_MODULE(SiPixelRecHitFromSoAAlpakaPhase2);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -3,7 +3,6 @@
 #include <fmt/printf.h>
 
 #include "DataFormats/Portable/interface/HostProductAlpaka.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitFromSoAAlpaka.cc
@@ -27,6 +27,14 @@
 
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
 
+/**
+ * \class SiPixelRecHitFromSoAAlpaka
+ *
+ * \brief EDProducer to convert SoA PixelRecHit collection to legacy (AoS) PixelRecHits
+ *
+ * The main method (produce()) loops over detUnits. Using the array holding the starting index of the hits belonging to each detUnit, it reconstruct RecHits belonging to that detUnit by accessing corresponding rows in SoA RecHit collections. The reconstructed RecHits are added the output (AoS) collection of SiPixelRecHits.
+ */ 
+
 template <typename TrackerTraits>
 class SiPixelRecHitFromSoAAlpaka : public edm::global::EDProducer<> {
   using HitModuleStartArray = typename TrackingRecHitAlpakaSoA<TrackerTraits>::HitModuleStartArray;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
@@ -1,0 +1,60 @@
+#include <memory>
+#include <string>
+#include <alpaka/alpaka.hpp>
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastAlpaka.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  template <typename TrackerTraits>
+  class PixelCPEFastParamsESProducerAlpaka : public ESProducer {
+  public:
+    PixelCPEFastParamsESProducerAlpaka(edm::ParameterSet const& iConfig);
+    std::optional<pixelCPEforDevice::PixelCPEFastParams<Device, TrackerTraits>> produce(device::EventSetup& es);
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  private:
+    const device::ESGetToken<PixelCPEFastAlpaka<TrackerTraits>, TkPixelCPERecord> cpeToken_;
+  };
+
+  template <typename TrackerTraits>
+  PixelCPEFastParamsESProducerAlpaka<TrackerTraits>::PixelCPEFastParamsESProducerAlpaka(edm::ParameterSet const& iConfig)
+      : ESProducer(iConfig) {
+    auto const& myname = iConfig.getParameter<std::string>("ComponentName");
+  }
+
+  template <typename TrackerTraits>
+  std::optional<pixelCPEforDevice::PixelCPEFastParams<Device, TrackerTraits>>
+  PixelCPEFastParamsESProducerAlpaka<TrackerTraits>::produce(device::EventSetup& es) {
+    auto const& pcpe = es.getData(cpeToken_);
+    auto pcpe_buf = cms::alpakatools::make_host_buffer<pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>, Platform>();
+    memcpy(pcpe_buf.data(), &pcpe.getCPEFastParams(), sizeof(pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>));
+
+    return pixelCPEforDevice::PixelCPEFastParams<Device, TrackerTraits>(pcpe_buf);
+  }
+
+  template <typename TrackerTraits>
+  void PixelCPEFastParamsESProducerAlpaka<TrackerTraits>::fillDescriptions(
+      edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    std::string name = "PixelCPEFast";
+    name += TrackerTraits::nameModifier;
+    desc.add<std::string>("ComponentName", name);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  using PixelCPEFastParamsESProducerAlpakaPhase1 = PixelCPEFastParamsESProducerAlpaka<pixelTopology::Phase1>;
+  using PixelCPEFastParamsESProducerAlpakaPhase2 = PixelCPEFastParamsESProducerAlpaka<pixelTopology::Phase2>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(PixelCPEFastParamsESProducerAlpakaPhase1);
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(PixelCPEFastParamsESProducerAlpakaPhase2);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
@@ -13,8 +13,10 @@
 #include "PixelRecHitGPUKernel.h"
 #include "pixelRecHits.h"
 
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using namespace cms::alpakatools;
+
   template <typename TrackerTraits>
   class setHitsLayerStart {
   public:

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
@@ -1,0 +1,124 @@
+// C++ headers
+#include <algorithm>
+#include <numeric>
+
+// Alpaka lib
+//#include <alpaka/alpaka.hpp>
+
+// CMSSW headers
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+
+#include "PixelRecHitGPUKernel.h"
+#include "pixelRecHits.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  using namespace cms::alpakatools;
+  template <typename TrackerTraits>
+  class setHitsLayerStart {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  uint32_t const* __restrict__ hitsModuleStart,
+                                  pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* cpeParams,
+                                  uint32_t* hitsLayerStart) const {
+      const int32_t i = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      constexpr auto m = TrackerTraits::numberOfLayers;
+
+      assert(0 == hitsModuleStart[0]);
+
+      if (i <= (int32_t)m) {
+        hitsLayerStart[i] = hitsModuleStart[cpeParams->layerGeometry().layerStart[i]];
+#ifdef GPU_DEBUG
+        int old = i == 0 ? 0 : hitsModuleStart[cpeParams->layerGeometry().layerStart[i - 1]];
+        printf("LayerStart %d/%d at module %d: %d - %d\n",
+               i,
+               m,
+               cpeParams->layerGeometry().layerStart[i],
+               hitsLayerStart[i],
+               hitsLayerStart[i] - old);
+#endif
+      }
+    }
+  };
+
+  namespace pixelgpudetails {
+
+    template <typename TrackerTraits>
+    TrackingRecHitAlpakaDevice<TrackerTraits> PixelRecHitGPUKernel<TrackerTraits>::makeHitsAsync(
+        SiPixelDigisDevice const& digis_d,
+        SiPixelClustersDevice const& clusters_d,
+        BeamSpotAlpaka const& bs_d,
+        pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* cpeParams,
+        Queue queue) const {
+      using namespace gpuPixelRecHits;
+      auto nHits = clusters_d.nClusters();
+
+      TrackingRecHitAlpakaDevice<TrackerTraits> hits_d(
+          nHits, clusters_d.offsetBPIX2(), cpeParams, clusters_d->clusModuleStart(), queue);
+
+      int activeModulesWithDigis = digis_d.nModules();
+      // protect from empty events
+      if (activeModulesWithDigis) {
+        int threadsPerBlock = 128;
+        int blocks = activeModulesWithDigis;
+        const auto workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(blocks, threadsPerBlock);
+
+#ifdef GPU_DEBUG
+        std::cout << "launching getHits kernel for " << blocks << " blocks" << std::endl;
+#endif
+        alpaka::exec<Acc1D>(queue,
+                            workDiv1D,
+                            getHits<TrackerTraits>{},
+                            cpeParams,
+                            bs_d.data(),
+                            digis_d.view(),
+                            digis_d.nDigis(),
+                            clusters_d.view(),
+                            hits_d.view());
+        // getHits<TrackerTraits><<<blocks, threadsPerBlock, 0, stream>>>(
+        //     cpeParams, bs_d.data(), digis_d.view(), digis_d.nDigis(), clusters_d.const_view(), hits_d.view());
+#ifdef GPU_DEBUG
+        alpaka::wait(queue);
+#endif
+
+        // assuming full warp of threads is better than a smaller number...
+        if (nHits) {
+          const auto workDiv1D = cms::alpakatools::make_workdiv<Acc1D>(1, 32);
+          // setHitsLayerStart<TrackerTraits>
+          //     <<<1, 32, 0, stream>>>(clusters_d->clusModuleStart(), cpeParams, hits_d.view().hitsLayerStart().data());
+          alpaka::exec<Acc1D>(queue,
+                              workDiv1D,
+                              setHitsLayerStart<TrackerTraits>{},
+                              clusters_d->clusModuleStart(),
+                              cpeParams,
+                              hits_d.view().hitsLayerStart().data());
+          constexpr auto nLayers = TrackerTraits::numberOfLayers;
+          cms::alpakatools::fillManyFromVector<Acc1D>(&(hits_d.view().phiBinner()),
+                                                      nLayers,
+                                                      hits_d.view().iphi(),
+                                                      hits_d.view().hitsLayerStart().data(),
+                                                      nHits,
+                                                      (uint32_t)256,
+                                                      queue);
+
+#ifdef GPU_DEBUG
+          alpaka::wait(queue);
+#endif
+        }
+      }
+
+#ifdef GPU_DEBUG
+      alpaka::wait(queue);
+      std::cout << "PixelRecHitGPUKernel -> DONE!" << std::endl;
+#endif
+
+      return hits_d;
+    }
+
+    template class PixelRecHitGPUKernel<pixelTopology::Phase1>;
+    template class PixelRecHitGPUKernel<pixelTopology::Phase2>;
+
+  }  // namespace pixelgpudetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
@@ -8,7 +8,7 @@
 // CMSSW headers
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaUtilities/interface/HistoContainer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
 
 #include "PixelRecHitGPUKernel.h"
 #include "pixelRecHits.h"

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
@@ -1,0 +1,42 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_PixelRecHitGPUKernel_h
+#define RecoLocalTracker_SiPixelRecHits_PixelRecHitGPUKernel_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace pixelgpudetails {
+    using namespace cms::alpakatools;
+
+    template <typename TrackerTraits>
+    class PixelRecHitGPUKernel {
+    public:
+      PixelRecHitGPUKernel() = default;
+      ~PixelRecHitGPUKernel() = default;
+
+      PixelRecHitGPUKernel(const PixelRecHitGPUKernel&) = delete;
+      PixelRecHitGPUKernel(PixelRecHitGPUKernel&&) = delete;
+      PixelRecHitGPUKernel& operator=(const PixelRecHitGPUKernel&) = delete;
+      PixelRecHitGPUKernel& operator=(PixelRecHitGPUKernel&&) = delete;
+
+      using ParamsOnGPU = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
+
+      TrackingRecHitAlpakaDevice<TrackerTraits> makeHitsAsync(SiPixelDigisDevice const& digis_d,
+                                                              SiPixelClustersDevice const& clusters_d,
+                                                              BeamSpotAlpaka const& bs_d,
+                                                              ParamsOnGPU const* cpeParams,
+                                                              Queue queue) const;
+    };
+  }  // namespace pixelgpudetails
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelRecHits_PixelRecHitGPUKernel_h

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
@@ -17,6 +17,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace pixelgpudetails {
     using namespace cms::alpakatools;
 
+   /**
+    * \class PixelRecHitGPUKernel
+    *
+    * \brief Sets up work division to build SoA TrackingRecHit collection from
+    *        SiPixelClusters and SiPixelDigis SoAs on the device.
+    *
+    * The main method is makeHitsAsync() which sends a block of 128 threads for each module with digis. Each thread processes its own digi and cluster into rechit. The SoA of RecHits is created using the fillManyFromVector() method
+    */
+
     template <typename TrackerTraits>
     class PixelRecHitGPUKernel {
     public:

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
 #include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -24,7 +24,19 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
 
 #include "PixelRecHitGPUKernel.h"
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  /**
+   * \class SiPixelRecHitAlpaka
+   *
+   * \brief EDProducer to produces RecHits asynchronously on a device.
+   *
+   * This EDProducer produces RecHits asynchronously on the GPU (device) per-event. After asynchronous production of the RecHit, the main method stores the resulting RecHit at the correct position in the device event.
+   *
+   * The main method (produce()) acts on a device's iEvent utilizing the target device's GPU kernel makeHitsAsync() method, which returns an SoA of RecHits from the input digits, clusters, beamspot and CPE on the device.
+   */
+
   template <typename TrackerTraits>
   class SiPixelRecHitAlpaka : public global::EDProducer<> {
   public:

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -1,0 +1,96 @@
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+#include "DataFormats/Portable/interface/Product.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitSoADevice.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "RecoLocalTracker/Records/interface/TkPixelCPERecord.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastAlpaka.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+
+#include "PixelRecHitGPUKernel.h"
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  template <typename TrackerTraits>
+  class SiPixelRecHitAlpaka : public global::EDProducer<> {
+  public:
+    explicit SiPixelRecHitAlpaka(const edm::ParameterSet& iConfig);
+    ~SiPixelRecHitAlpaka() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    using ParamsOnGPU = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
+
+  private:
+    void produce(edm::StreamID streamID, device::Event& iEvent, const device::EventSetup& iSetup) const override;
+
+    const device::ESGetToken<pixelCPEforDevice::PixelCPEFastParams<Device, TrackerTraits>, TkPixelCPERecord> cpeToken_;
+    const device::EDGetToken<BeamSpotAlpaka> tBeamSpot;
+    const device::EDGetToken<SiPixelClustersDevice> tokenClusters_;
+    const device::EDGetToken<SiPixelDigisDevice> tokenDigi_;
+    const device::EDPutToken<TrackingRecHitAlpakaDevice<TrackerTraits>> tokenHit_;
+
+    const pixelgpudetails::PixelRecHitGPUKernel<TrackerTraits> gpuAlgo_;
+  };
+
+  template <typename TrackerTraits>
+  SiPixelRecHitAlpaka<TrackerTraits>::SiPixelRecHitAlpaka(const edm::ParameterSet& iConfig)
+      : cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
+        tBeamSpot(consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+        tokenClusters_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+        tokenDigi_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+        tokenHit_(produces()) {}
+
+  template <typename TrackerTraits>
+  void SiPixelRecHitAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpotAlpaka"));
+    desc.add<edm::InputTag>("src", edm::InputTag("siPixelClustersPreSplittingAlpaka"));
+
+    std::string cpe = "PixelCPEFast";
+    cpe += TrackerTraits::nameModifier;
+    desc.add<std::string>("CPE", cpe);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  template <typename TrackerTraits>
+  void SiPixelRecHitAlpaka<TrackerTraits>::produce(edm::StreamID streamID,
+                                                   device::Event& iEvent,
+                                                   const device::EventSetup& es) const {
+    auto& fcpe = es.getData(cpeToken_);
+    if (not fcpe.data()) {
+      throw cms::Exception("Configuration") << "SiPixelRecHitAlpaka can only use a CPE of type PixelCPEFast";
+    }
+
+    auto const& clusters = iEvent.get(tokenClusters_);
+
+    auto const& digis = iEvent.get(tokenDigi_);
+
+    auto const& bs = iEvent.get(tBeamSpot);
+
+    iEvent.emplace(tokenHit_, gpuAlgo_.makeHitsAsync(digis, clusters, bs, fcpe.data(), iEvent.queue()));
+  }
+  using SiPixelRecHitAlpakaPhase1 = SiPixelRecHitAlpaka<pixelTopology::Phase1>;
+  using SiPixelRecHitAlpakaPhase2 = SiPixelRecHitAlpaka<pixelTopology::Phase2>;
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(SiPixelRecHitAlpakaPhase1);
+DEFINE_FWK_ALPAKA_MODULE(SiPixelRecHitAlpakaPhase2);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
@@ -1,0 +1,240 @@
+#ifndef RecoLocalTracker_SiPixelRecHits_gpuPixelRecHits_h
+#define RecoLocalTracker_SiPixelRecHits_gpuPixelRecHits_h
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "DataFormats/BeamSpotAlpaka/interface/alpaka/BeamSpotAlpaka.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisDevice.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+
+//#define GPU_DEBUG 1
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  namespace gpuPixelRecHits {
+
+    template <typename TrackerTraits>
+    class getHits {
+    public:
+      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+      ALPAKA_FN_ACC void operator()(const TAcc& acc,
+                                    pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* __restrict__ cpeParams,
+                                    BeamSpotPOD const* __restrict__ bs,
+                                    SiPixelDigisLayoutSoAConstView digis,
+                                    uint32_t numElements,
+                                    SiPixelClustersLayoutSoAConstView clusters,
+                                    TrackingRecHitAlpakaSoAView<TrackerTraits> hits) const {
+        // FIXME
+        // the compiler seems NOT to optimize loads from views (even in a simple test case)
+        // The whole gimnastic here of copying or not is a pure heuristic exercise that seems to produce the fastest code with the above signature
+        // not using views (passing a gazzilion of array pointers) seems to produce the fastest code (but it is harder to mantain)
+
+        ALPAKA_ASSERT_OFFLOAD(cpeParams);
+
+        const uint32_t blockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
+        const uint32_t threadIdxLocal(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
+
+        // copy average geometry corrected by beamspot . FIXME (move it somewhere else???)
+        if (0 == blockIdx) {
+          auto& agc = hits.averageGeometry();
+          auto const& ag = cpeParams->averageGeometry();
+          auto nLadders = TrackerTraits::numberOfLaddersInBarrel;
+
+          cms::alpakatools::for_each_element_in_block_strided(acc, nLadders, [&](uint32_t il) {
+            agc.ladderZ[il] = ag.ladderZ[il] - bs->z;
+            agc.ladderX[il] = ag.ladderX[il] - bs->x;
+            agc.ladderY[il] = ag.ladderY[il] - bs->y;
+            agc.ladderR[il] = sqrt(agc.ladderX[il] * agc.ladderX[il] + agc.ladderY[il] * agc.ladderY[il]);
+            agc.ladderMinZ[il] = ag.ladderMinZ[il] - bs->z;
+            agc.ladderMaxZ[il] = ag.ladderMaxZ[il] - bs->z;
+          });
+
+          if (0 == threadIdxLocal) {
+            agc.endCapZ[0] = ag.endCapZ[0] - bs->z;
+            agc.endCapZ[1] = ag.endCapZ[1] - bs->z;
+          }
+        }
+
+        // to be moved in common namespace...
+        using pixelClustering::invalidModuleId;
+        constexpr int32_t MaxHitsInIter = pixelCPEforDevice::MaxHitsInIter;
+
+        using ClusParams = pixelCPEforDevice::ClusParams;
+
+        // as usual one block per module
+        auto& clusParams = alpaka::declareSharedVar<ClusParams, __COUNTER__>(acc);
+
+        auto me = clusters[blockIdx].moduleId();
+        int nclus = clusters[me].clusInModule();
+
+        if (0 == nclus)
+          return;
+#ifdef GPU_DEBUG
+        if (threadIdx == 0) {
+          auto k = clusters[1 + blockIdx.x].moduleStart();
+          while (digis[k].moduleId() == invalidModuleId)
+            ++k;
+          ALPAKA_ASSERT_OFFLOAD(digis[k].moduleId() == me);
+        }
+
+        if (me % 100 == 1)
+          if (threadIdx == 0)
+            printf(
+                "hitbuilder: %d clusters in module %d. will write at %d\n", nclus, me, clusters[me].clusModuleStart());
+#endif
+
+        for (int startClus = 0, endClus = nclus; startClus < endClus; startClus += MaxHitsInIter) {
+          auto first = clusters[me].clusModuleStart() + startClus;
+
+          int nClusInIter = alpaka::math::min(acc, MaxHitsInIter, endClus - startClus);
+          int lastClus = startClus + nClusInIter;
+          assert(nClusInIter <= nclus);
+          assert(nClusInIter > 0);
+          assert(lastClus <= nclus);
+
+          assert(nclus > MaxHitsInIter || (0 == startClus && nClusInIter == nclus && lastClus == nclus));
+
+          // init
+          cms::alpakatools::for_each_element_in_block_strided(acc, nClusInIter, [&](uint32_t ic) {
+            clusParams.minRow[ic] = std::numeric_limits<uint32_t>::max();
+            clusParams.maxRow[ic] = 0;
+            clusParams.minCol[ic] = std::numeric_limits<uint32_t>::max();
+            clusParams.maxCol[ic] = 0;
+            clusParams.charge[ic] = 0;
+            clusParams.q_f_X[ic] = 0;
+            clusParams.q_l_X[ic] = 0;
+            clusParams.q_f_Y[ic] = 0;
+            clusParams.q_l_Y[ic] = 0;
+          });
+
+          alpaka::syncBlockThreads(acc);
+
+          // one thread per "digi"
+          const uint32_t blockDimension(alpaka::getWorkDiv<alpaka::Block, alpaka::Elems>(acc)[0u]);
+          const auto& [firstElementIdxNoStride, endElementIdxNoStride] =
+              cms::alpakatools::element_index_range_in_block(acc, first);
+          uint32_t rowsColsFirstElementIdx = firstElementIdxNoStride;
+          uint32_t rowsColsEndElementIdx = endElementIdxNoStride;
+          for (uint32_t i = rowsColsFirstElementIdx; i < numElements; ++i) {
+            if (not cms::alpakatools::next_valid_element_index_strided(
+                    i, rowsColsFirstElementIdx, rowsColsEndElementIdx, blockDimension, numElements))
+              break;
+            auto id = digis[i].moduleId();
+            if (id == invalidModuleId)
+              continue;  // not valid
+            if (id != me)
+              break;  // end of module
+            auto cl = digis[i].clus();
+            if (cl < startClus || cl >= lastClus)
+              continue;
+            cl -= startClus;
+            ALPAKA_ASSERT_OFFLOAD(cl >= 0);
+            ALPAKA_ASSERT_OFFLOAD(cl < MaxHitsInIter);
+            auto x = digis[i].xx();
+            auto y = digis[i].yy();
+            alpaka::atomicMin(acc, &clusParams.minRow[cl], (uint32_t)x, alpaka::hierarchy::Threads{});
+            alpaka::atomicMax(acc, &clusParams.maxRow[cl], (uint32_t)x, alpaka::hierarchy::Threads{});
+            alpaka::atomicMin(acc, &clusParams.minCol[cl], (uint32_t)y, alpaka::hierarchy::Threads{});
+            alpaka::atomicMax(acc, &clusParams.maxCol[cl], (uint32_t)y, alpaka::hierarchy::Threads{});
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          auto pixmx = cpeParams->detParams(me).pixmx;
+          uint32_t chargeFirstElementIdx = firstElementIdxNoStride;
+          uint32_t chargeEndElementIdx = endElementIdxNoStride;
+          for (uint32_t i = chargeFirstElementIdx; i < numElements; ++i) {
+            if (not cms::alpakatools::next_valid_element_index_strided(
+                    i, chargeFirstElementIdx, chargeEndElementIdx, blockDimension, numElements))
+              break;
+            auto id = digis[i].moduleId();
+            if (id == invalidModuleId)
+              continue;  // not valid
+            if (id != me)
+              break;  // end of module
+            auto cl = digis[i].clus();
+            if (cl < startClus || cl >= lastClus)
+              continue;
+            cl -= startClus;
+            ALPAKA_ASSERT_OFFLOAD(cl >= 0);
+            ALPAKA_ASSERT_OFFLOAD(cl < MaxHitsInIter);
+            auto x = digis[i].xx();
+            auto y = digis[i].yy();
+            auto ch = digis[i].adc();
+            alpaka::atomicAdd(acc, &clusParams.charge[cl], (int32_t)ch, alpaka::hierarchy::Threads{});
+            ch = alpaka::math::min(acc, ch, pixmx);
+            if (clusParams.minRow[cl] == x)
+              alpaka::atomicAdd(acc, &clusParams.q_f_X[cl], (int32_t)ch, alpaka::hierarchy::Threads{});
+            if (clusParams.maxRow[cl] == x)
+              alpaka::atomicAdd(acc, &clusParams.q_l_X[cl], (int32_t)ch, alpaka::hierarchy::Threads{});
+            if (clusParams.minCol[cl] == y)
+              alpaka::atomicAdd(acc, &clusParams.q_f_Y[cl], (int32_t)ch, alpaka::hierarchy::Threads{});
+            if (clusParams.maxCol[cl] == y)
+              alpaka::atomicAdd(acc, &clusParams.q_l_Y[cl], (int32_t)ch, alpaka::hierarchy::Threads{});
+          }
+
+          alpaka::syncBlockThreads(acc);
+
+          // next one cluster per thread...
+
+          cms::alpakatools::for_each_element_in_block_strided(acc, nClusInIter, [&](uint32_t ic) {
+            auto h = first + ic;  // output index in global memory
+
+            assert(h < hits.nHits());
+            assert(h < clusters[me + 1].clusModuleStart());
+
+            pixelCPEforDevice::position<TrackerTraits>(
+                cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
+
+            pixelCPEforDevice::errorFromDB<TrackerTraits>(
+                cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
+
+            // store it
+            hits[h].chargeAndStatus().charge = clusParams.charge[ic];
+            hits[h].chargeAndStatus().status = clusParams.status[ic];
+            hits[h].detectorIndex() = me;
+
+            float xl, yl;
+            hits[h].xLocal() = xl = clusParams.xpos[ic];
+            hits[h].yLocal() = yl = clusParams.ypos[ic];
+
+            hits[h].clusterSizeX() = clusParams.xsize[ic];
+            hits[h].clusterSizeY() = clusParams.ysize[ic];
+
+            hits[h].xerrLocal() = clusParams.xerr[ic] * clusParams.xerr[ic] + cpeParams->detParams(me).apeXX;
+            hits[h].yerrLocal() = clusParams.yerr[ic] * clusParams.yerr[ic] + cpeParams->detParams(me).apeYY;
+
+            // keep it local for computations
+            float xg, yg, zg;
+            // to global and compute phi...
+            cpeParams->detParams(me).frame.toGlobal(xl, yl, xg, yg, zg);
+            // here correct for the beamspot...
+            xg -= bs->x;
+            yg -= bs->y;
+            zg -= bs->z;
+
+            hits[h].xGlobal() = xg;
+            hits[h].yGlobal() = yg;
+            hits[h].zGlobal() = zg;
+
+            hits[h].rGlobal() = alpaka::math::sqrt(acc, xg * xg + yg * yg);
+            hits[h].iphi() = unsafe_atan2s<7>(yg, xg);
+          });
+          alpaka::syncBlockThreads(acc);
+        }  // end loop on batches
+      }
+    };
+
+  }  // namespace gpuPixelRecHits
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // RecoLocalTracker_SiPixelRecHits_plugins_gpuPixelRecHits_h

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
@@ -18,9 +18,21 @@
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
 
+
 //#define GPU_DEBUG 1
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace gpuPixelRecHits {
+
+   /**
+    * \class getHits
+    *
+    * \brief Used to build SoA TrackingRecHit collection from SiPixelClusters and SiPixelDigis SoAs.
+    *
+    * This class is used to produce the collection of PixelRecHits out of SiPixelDigis and SiPixelClusters. All three collections are used in the form of SoA. Looping over digis is done to set cluster properties needed for position estimation. This is then followed by looping over clusters to create RecHits.
+    *
+    * The only method (operator()) is called asynchronously and processes clusters from one module per one block of threads. It determines and set cluster properties such as charge and cluster edges using the information from the collection of digis. These properties are then used to generate recHits from clusters (one cluster per thread). It calls pixelCPEforDevice to determine the position and errors of the rec hits.
+    *
+    */
 
     template <typename TrackerTraits>
     class getHits {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastAlpaka.cc
@@ -1,0 +1,499 @@
+
+#include "CondFormats/SiPixelTransient/interface/SiPixelTemplate.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastAlpaka.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
+
+// Services
+// this is needed to get errors from templates
+
+namespace {
+  constexpr float micronsToCm = 1.0e-4;
+}
+
+//-----------------------------------------------------------------------------
+//!  The constructor.
+//-----------------------------------------------------------------------------
+template <typename TrackerTraits>
+PixelCPEFastAlpaka<TrackerTraits>::PixelCPEFastAlpaka(edm::ParameterSet const& conf,
+                                                      const MagneticField* mag,
+                                                      const TrackerGeometry& geom,
+                                                      const TrackerTopology& ttopo,
+                                                      const SiPixelLorentzAngle* lorentzAngle,
+                                                      const SiPixelGenErrorDBObject* genErrorDBObject,
+                                                      const SiPixelLorentzAngle* lorentzAngleWidth)
+    : PixelCPEGenericBase(conf, mag, geom, ttopo, lorentzAngle, genErrorDBObject, lorentzAngleWidth) {
+  // Use errors from templates or from GenError
+  if (useErrorsFromTemplates_) {
+    if (!SiPixelGenError::pushfile(*genErrorDBObject_, thePixelGenError_))
+      throw cms::Exception("InvalidCalibrationLoaded")
+          << "ERROR: GenErrors not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+          << (*genErrorDBObject_).version();
+  }
+
+  initializeParams();
+}
+
+// Initialize the CPE Params on host.
+template <typename TrackerTraits>
+void PixelCPEFastAlpaka<TrackerTraits>::initializeParams() {
+  // this code executes only once per job, computation inefficiency is not an issue
+  // many code blocks are repeated: better keep the computation local and self oconsistent as blocks may in future move around, be deleted ...
+  // It is valid only for Phase1 and the version of GenError in DB used in late 2018 and in 2021
+  auto& commonParams_ = cpeParams_.m_commonParams;
+  auto& detParams_ = cpeParams_.m_detParams;
+  auto& layerGeometry_ = cpeParams_.m_layerGeometry;
+  auto& averageGeometry_ = cpeParams_.m_averageGeometry;
+
+  commonParams_.theThicknessB = m_DetParams.front().theThickness;
+  commonParams_.theThicknessE = m_DetParams.back().theThickness;
+  commonParams_.thePitchX = m_DetParams[0].thePitchX;
+  commonParams_.thePitchY = m_DetParams[0].thePitchY;
+
+  commonParams_.numberOfLaddersInBarrel = TrackerTraits::numberOfLaddersInBarrel;
+
+  LogDebug("PixelCPEFastAlpaka") << "pitch & thickness " << commonParams_.thePitchX << ' ' << commonParams_.thePitchY
+                                 << "  " << commonParams_.theThicknessB << ' ' << commonParams_.theThicknessE;
+
+  // zero average geometry
+  memset(&averageGeometry_, 0, sizeof(pixelTopology::AverageGeometryT<TrackerTraits>));
+
+  uint32_t oldLayer = 0;
+  uint32_t oldLadder = 0;
+  float rl = 0;
+  float zl = 0;
+  float miz = 500, mxz = 0;
+  float pl = 0;
+  int nl = 0;
+  // detParams_.resize(m_DetParams.size());
+
+  for (auto i = 0U; i < m_DetParams.size(); ++i) {
+    auto& p = m_DetParams[i];
+    auto& g = detParams_[i];
+
+    g.nRowsRoc = p.theDet->specificTopology().rowsperroc();
+    g.nColsRoc = p.theDet->specificTopology().colsperroc();
+    g.nRows = p.theDet->specificTopology().rocsX() * g.nRowsRoc;
+    g.nCols = p.theDet->specificTopology().rocsY() * g.nColsRoc;
+
+    g.numPixsInModule = g.nRows * g.nCols;
+
+    assert(p.theDet->index() == int(i));
+    assert(commonParams_.thePitchY == p.thePitchY);
+    assert(commonParams_.thePitchX == p.thePitchX);
+
+    g.isBarrel = GeomDetEnumerators::isBarrel(p.thePart);
+    g.isPosZ = p.theDet->surface().position().z() > 0;
+    g.layer = ttopo_.layer(p.theDet->geographicalId());
+    g.index = i;  // better be!
+    g.rawId = p.theDet->geographicalId();
+    auto thickness = g.isBarrel ? commonParams_.theThicknessB : commonParams_.theThicknessE;
+    assert(thickness == p.theThickness);
+
+    auto ladder = ttopo_.pxbLadder(p.theDet->geographicalId());
+    if (oldLayer != g.layer) {
+      oldLayer = g.layer;
+      LogDebug("PixelCPEFastAlpaka") << "new layer at " << i << (g.isBarrel ? " B  " : (g.isPosZ ? " E+ " : " E- "))
+                                     << g.layer << " starting at " << g.rawId << '\n'
+                                     << "old layer had " << nl << " ladders";
+      nl = 0;
+    }
+    if (oldLadder != ladder) {
+      oldLadder = ladder;
+      LogDebug("PixelCPEFastAlpaka") << "new ladder at " << i << (g.isBarrel ? " B  " : (g.isPosZ ? " E+ " : " E- "))
+                                     << ladder << " starting at " << g.rawId << '\n'
+                                     << "old ladder ave z,r,p mz " << zl / 8.f << " " << rl / 8.f << " " << pl / 8.f
+                                     << ' ' << miz << ' ' << mxz;
+      rl = 0;
+      zl = 0;
+      pl = 0;
+      miz = 500;
+      mxz = 0;
+      nl++;
+    }
+
+    g.shiftX = 0.5f * p.lorentzShiftInCmX;
+    g.shiftY = 0.5f * p.lorentzShiftInCmY;
+    g.chargeWidthX = p.lorentzShiftInCmX * p.widthLAFractionX;
+    g.chargeWidthY = p.lorentzShiftInCmY * p.widthLAFractionY;
+
+    g.x0 = p.theOrigin.x();
+    g.y0 = p.theOrigin.y();
+    g.z0 = p.theOrigin.z();
+
+    auto vv = p.theDet->surface().position();
+    auto rr = pixelCPEforDevice::Rotation(p.theDet->surface().rotation());
+    g.frame = pixelCPEforDevice::Frame(vv.x(), vv.y(), vv.z(), rr);
+
+    zl += vv.z();
+    miz = std::min(miz, std::abs(vv.z()));
+    mxz = std::max(mxz, std::abs(vv.z()));
+    rl += vv.perp();
+    pl += vv.phi();  // (not obvious)
+
+    // errors .....
+    ClusterParamGeneric cp;
+
+    cp.with_track_angle = false;
+
+    auto lape = p.theDet->localAlignmentError();
+    if (lape.invalid())
+      lape = LocalError();  // zero....
+
+    g.apeXX = lape.xx();
+    g.apeYY = lape.yy();
+
+    auto toMicron = [&](float x) { return std::min(511, int(x * 1.e4f + 0.5f)); };
+
+    // average angle
+    auto gvx = p.theOrigin.x() + 40.f * commonParams_.thePitchX;
+    auto gvy = p.theOrigin.y();
+    auto gvz = 1.f / p.theOrigin.z();
+    //--- Note that the normalization is not required as only the ratio used
+
+    {
+      // calculate angles (fed into errorFromTemplates)
+      cp.cotalpha = gvx * gvz;
+      cp.cotbeta = gvy * gvz;
+
+      errorFromTemplates(p, cp, 20000.);
+    }
+
+#ifdef EDM_ML_DEBUG
+    auto m = 10000.f;
+    for (float qclus = 15000; qclus < 35000; qclus += 15000) {
+      errorFromTemplates(p, cp, qclus);
+      LogDebug("PixelCPEFastAlpaka") << i << ' ' << qclus << ' ' << cp.pixmx << ' ' << m * cp.sigmax << ' '
+                                     << m * cp.sx1 << ' ' << m * cp.sx2 << ' ' << m * cp.sigmay << ' ' << m * cp.sy1
+                                     << ' ' << m * cp.sy2;
+    }
+    LogDebug("PixelCPEFastAlpaka") << i << ' ' << m * std::sqrt(lape.xx()) << ' ' << m * std::sqrt(lape.yy());
+#endif  // EDM_ML_DEBUG
+
+    g.pixmx = std::max(0, cp.pixmx);
+    g.sx2 = toMicron(cp.sx2);
+    g.sy1 = std::max(21, toMicron(cp.sy1));  // for some angles sy1 is very small
+    g.sy2 = std::max(55, toMicron(cp.sy2));  // sometimes sy2 is smaller than others (due to angle?)
+
+    //sample xerr as function of position
+    // moduleOffsetX is the definition of TrackerTraits::xOffset,
+    // needs to be calculated because for Phase2 the modules are not uniform
+    float moduleOffsetX = -(0.5f * float(g.nRows) + TrackerTraits::bigPixXCorrection);
+    auto const xoff = moduleOffsetX * commonParams_.thePitchX;
+
+    for (int ix = 0; ix < CPEFastParametrisation::kNumErrorBins; ++ix) {
+      auto x = xoff * (1.f - (0.5f + float(ix)) / 8.f);
+      auto gvx = p.theOrigin.x() - x;
+      auto gvy = p.theOrigin.y();
+      auto gvz = 1.f / p.theOrigin.z();
+      cp.cotbeta = gvy * gvz;
+      cp.cotalpha = gvx * gvz;
+      errorFromTemplates(p, cp, 20000.f);
+      g.sigmax[ix] = toMicron(cp.sigmax);
+      g.sigmax1[ix] = toMicron(cp.sx1);
+      LogDebug("PixelCPEFastAlpaka") << "sigmax vs x " << i << ' ' << x << ' ' << cp.cotalpha << ' '
+                                     << int(g.sigmax[ix]) << ' ' << int(g.sigmax1[ix]) << ' ' << 10000.f * cp.sigmay
+                                     << std::endl;
+    }
+#ifdef EDM_ML_DEBUG
+    // sample yerr as function of position
+    // moduleOffsetY is the definition of TrackerTraits::yOffset (removed)
+    float moduleOffsetY = 0.5f * float(g.nCols) + TrackerTraits::bigPixYCorrection;
+    auto const yoff = -moduleOffsetY * commonParams_.thePitchY;
+
+    for (int ix = 0; ix < CPEFastParametrisation::kNumErrorBins; ++ix) {
+      auto y = yoff * (1.f - (0.5f + float(ix)) / 8.f);
+      auto gvx = p.theOrigin.x() + 40.f * commonParams_.thePitchY;
+      auto gvy = p.theOrigin.y() - y;
+      auto gvz = 1.f / p.theOrigin.z();
+      cp.cotbeta = gvy * gvz;
+      cp.cotalpha = gvx * gvz;
+      errorFromTemplates(p, cp, 20000.f);
+      LogDebug("PixelCPEFastAlpaka") << "sigmay vs y " << i << ' ' << y << ' ' << cp.cotbeta << ' '
+                                     << 10000.f * cp.sigmay << std::endl;
+    }
+#endif  // EDM_ML_DEBUG
+
+    // calculate angles (repeated)
+    cp.cotalpha = gvx * gvz;
+    cp.cotbeta = gvy * gvz;
+    auto aveCB = cp.cotbeta;
+
+    // sample x by charge
+    int qbin = CPEFastParametrisation::kGenErrorQBins;  // low charge
+    int k = 0;
+    for (int qclus = 1000; qclus < 200000; qclus += 1000) {
+      errorFromTemplates(p, cp, qclus);
+      if (cp.qBin_ == qbin)
+        continue;
+      qbin = cp.qBin_;
+      g.xfact[k] = cp.sigmax;
+      g.yfact[k] = cp.sigmay;
+      g.minCh[k++] = qclus;
+#ifdef EDM_ML_DEBUG
+      LogDebug("PixelCPEFastAlpaka") << i << ' ' << g.rawId << ' ' << cp.cotalpha << ' ' << qclus << ' ' << cp.qBin_
+                                     << ' ' << cp.pixmx << ' ' << m * cp.sigmax << ' ' << m * cp.sx1 << ' '
+                                     << m * cp.sx2 << ' ' << m * cp.sigmay << ' ' << m * cp.sy1 << ' ' << m * cp.sy2
+                                     << std::endl;
+#endif  // EDM_ML_DEBUG
+    }
+
+    assert(k <= CPEFastParametrisation::kGenErrorQBins);
+
+    // fill the rest  (sometimes bin 4 is missing)
+    for (int kk = k; kk < CPEFastParametrisation::kGenErrorQBins; ++kk) {
+      g.xfact[kk] = g.xfact[k - 1];
+      g.yfact[kk] = g.yfact[k - 1];
+      g.minCh[kk] = g.minCh[k - 1];
+    }
+    auto detx = 1.f / g.xfact[0];
+    auto dety = 1.f / g.yfact[0];
+    for (int kk = 0; kk < CPEFastParametrisation::kGenErrorQBins; ++kk) {
+      g.xfact[kk] *= detx;
+      g.yfact[kk] *= dety;
+    }
+    // sample y in "angle"  (estimated from cluster size)
+    float ys = 8.f - 4.f;  // apperent bias of half pixel (see plot)
+    // plot: https://indico.cern.ch/event/934821/contributions/3974619/attachments/2091853/3515041/DigilessReco.pdf page 25
+    // sample yerr as function of "size"
+    for (int iy = 0; iy < CPEFastParametrisation::kNumErrorBins; ++iy) {
+      ys += 1.f;  // first bin 0 is for size 9  (and size is in fixed point 2^3)
+      if (CPEFastParametrisation::kNumErrorBins - 1 == iy)
+        ys += 8.f;  // last bin for "overflow"
+      // cp.cotalpha = ys*(commonParams_.thePitchX/(8.f*thickness));  //  use this to print sampling in "x"  (and comment the line below)
+      cp.cotbeta = std::copysign(ys * (commonParams_.thePitchY / (8.f * thickness)), aveCB);
+      errorFromTemplates(p, cp, 20000.f);
+      g.sigmay[iy] = toMicron(cp.sigmay);
+      LogDebug("PixelCPEFastAlpaka") << "sigmax/sigmay " << i << ' ' << (ys + 4.f) / 8.f << ' ' << cp.cotalpha << '/'
+                                     << cp.cotbeta << ' ' << 10000.f * cp.sigmax << '/' << int(g.sigmay[iy])
+                                     << std::endl;
+    }
+  }  // loop over det
+
+  constexpr int numberOfModulesInLadder = TrackerTraits::numberOfModulesInLadder;
+  constexpr int numberOfLaddersInBarrel = TrackerTraits::numberOfLaddersInBarrel;
+  constexpr int numberOfModulesInBarrel = TrackerTraits::numberOfModulesInBarrel;
+
+  constexpr float ladderFactor = 1.f / float(numberOfModulesInLadder);
+
+  constexpr int firstEndcapPos = TrackerTraits::firstEndcapPos;
+  constexpr int firstEndcapNeg = TrackerTraits::firstEndcapNeg;
+
+  // compute ladder baricenter (only in global z) for the barrel
+  //
+  auto& aveGeom = averageGeometry_;
+  int il = 0;
+  for (int im = 0, nm = numberOfModulesInBarrel; im < nm; ++im) {
+    auto const& g = detParams_[im];
+    il = im / numberOfModulesInLadder;
+    assert(il < int(numberOfLaddersInBarrel));
+    auto z = g.frame.z();
+    aveGeom.ladderZ[il] += ladderFactor * z;
+    aveGeom.ladderMinZ[il] = std::min(aveGeom.ladderMinZ[il], z);
+    aveGeom.ladderMaxZ[il] = std::max(aveGeom.ladderMaxZ[il], z);
+    aveGeom.ladderX[il] += ladderFactor * g.frame.x();
+    aveGeom.ladderY[il] += ladderFactor * g.frame.y();
+    aveGeom.ladderR[il] += ladderFactor * sqrt(g.frame.x() * g.frame.x() + g.frame.y() * g.frame.y());
+  }
+  assert(il + 1 == int(numberOfLaddersInBarrel));
+  // add half_module and tollerance
+  constexpr float moduleLength = TrackerTraits::moduleLength;
+  constexpr float module_tolerance = 0.2f;
+  for (int il = 0, nl = numberOfLaddersInBarrel; il < nl; ++il) {
+    aveGeom.ladderMinZ[il] -= (0.5f * moduleLength - module_tolerance);
+    aveGeom.ladderMaxZ[il] += (0.5f * moduleLength - module_tolerance);
+  }
+
+  // compute "max z" for first layer in endcap (should we restrict to the outermost ring?)
+  for (auto im = TrackerTraits::layerStart[firstEndcapPos]; im < TrackerTraits::layerStart[firstEndcapPos + 1]; ++im) {
+    auto const& g = detParams_[im];
+    aveGeom.endCapZ[0] = std::max(aveGeom.endCapZ[0], g.frame.z());
+  }
+  for (auto im = TrackerTraits::layerStart[firstEndcapNeg]; im < TrackerTraits::layerStart[firstEndcapNeg + 1]; ++im) {
+    auto const& g = detParams_[im];
+    aveGeom.endCapZ[1] = std::min(aveGeom.endCapZ[1], g.frame.z());
+  }
+  // correct for outer ring being closer
+  aveGeom.endCapZ[0] -= TrackerTraits::endcapCorrection;
+  aveGeom.endCapZ[1] += TrackerTraits::endcapCorrection;
+#ifdef EDM_ML_DEBUG
+  for (int jl = 0, nl = numberOfLaddersInBarrel; jl < nl; ++jl) {
+    LogDebug("PixelCPEFastAlpaka") << jl << ':' << aveGeom.ladderR[jl] << '/'
+                                   << std::sqrt(aveGeom.ladderX[jl] * aveGeom.ladderX[jl] +
+                                                aveGeom.ladderY[jl] * aveGeom.ladderY[jl])
+                                   << ',' << aveGeom.ladderZ[jl] << ',' << aveGeom.ladderMinZ[jl] << ','
+                                   << aveGeom.ladderMaxZ[jl] << '\n';
+  }
+  LogDebug("PixelCPEFastAlpaka") << aveGeom.endCapZ[0] << ' ' << aveGeom.endCapZ[1];
+#endif  // EDM_ML_DEBUG
+
+  // fill Layer and ladders geometry
+  memset(&layerGeometry_, 0, sizeof(pixelCPEforDevice::LayerGeometryT<TrackerTraits>));
+  memcpy(layerGeometry_.layerStart,
+         TrackerTraits::layerStart,
+         sizeof(pixelCPEforDevice::LayerGeometryT<TrackerTraits>::layerStart));
+  memcpy(layerGeometry_.layer, pixelTopology::layer<TrackerTraits>.data(), pixelTopology::layer<TrackerTraits>.size());
+  layerGeometry_.maxModuleStride = pixelTopology::maxModuleStride<TrackerTraits>;
+}
+
+// template <typename TrackerTraits>
+// PixelCPEFastAlpaka<TrackerTraits>::GPUData::~GPUData() {
+//   if (paramsOnGPU_d != nullptr) {
+//     cudaFree((void*)paramsOnGPU_h.m_commonParams);
+//     cudaFree((void*)paramsOnGPU_h.m_detParams);
+//     cudaFree((void*)paramsOnGPU_h.m_averageGeometry);
+//     cudaFree((void*)paramsOnGPU_h.m_layerGeometry);
+//     cudaFree(paramsOnGPU_d);
+//   }
+// }
+
+template <typename TrackerTraits>
+void PixelCPEFastAlpaka<TrackerTraits>::errorFromTemplates(DetParam const& theDetParam,
+                                                           ClusterParamGeneric& theClusterParam,
+                                                           float qclus) const {
+  float locBz = theDetParam.bz;
+  float locBx = theDetParam.bx;
+  LogDebug("PixelCPEFastAlpaka") << "PixelCPEFastAlpaka::localPosition(...) : locBz = " << locBz;
+
+  theClusterParam.pixmx = std::numeric_limits<int>::max();  // max pixel charge for truncation of 2-D cluster
+
+  theClusterParam.sigmay = -999.9;  // CPE Generic y-error for multi-pixel cluster
+  theClusterParam.sigmax = -999.9;  // CPE Generic x-error for multi-pixel cluster
+  theClusterParam.sy1 = -999.9;     // CPE Generic y-error for single single-pixel
+  theClusterParam.sy2 = -999.9;     // CPE Generic y-error for single double-pixel cluster
+  theClusterParam.sx1 = -999.9;     // CPE Generic x-error for single single-pixel cluster
+  theClusterParam.sx2 = -999.9;     // CPE Generic x-error for single double-pixel cluster
+
+  float dummy;
+
+  SiPixelGenError gtempl(thePixelGenError_);
+  int gtemplID = theDetParam.detTemplateId;
+
+  theClusterParam.qBin_ = gtempl.qbin(gtemplID,
+                                      theClusterParam.cotalpha,
+                                      theClusterParam.cotbeta,
+                                      locBz,
+                                      locBx,
+                                      qclus,
+                                      false,
+                                      theClusterParam.pixmx,
+                                      theClusterParam.sigmay,
+                                      dummy,
+                                      theClusterParam.sigmax,
+                                      dummy,
+                                      theClusterParam.sy1,
+                                      dummy,
+                                      theClusterParam.sy2,
+                                      dummy,
+                                      theClusterParam.sx1,
+                                      dummy,
+                                      theClusterParam.sx2,
+                                      dummy);
+
+  theClusterParam.sigmax = theClusterParam.sigmax * micronsToCm;
+  theClusterParam.sx1 = theClusterParam.sx1 * micronsToCm;
+  theClusterParam.sx2 = theClusterParam.sx2 * micronsToCm;
+
+  theClusterParam.sigmay = theClusterParam.sigmay * micronsToCm;
+  theClusterParam.sy1 = theClusterParam.sy1 * micronsToCm;
+  theClusterParam.sy2 = theClusterParam.sy2 * micronsToCm;
+}
+
+template <>
+void PixelCPEFastAlpaka<pixelTopology::Phase2>::errorFromTemplates(DetParam const& theDetParam,
+                                                                   ClusterParamGeneric& theClusterParam,
+                                                                   float qclus) const {
+  theClusterParam.qBin_ = 0.0f;
+}
+
+//-----------------------------------------------------------------------------
+//! Hit position in the local frame (in cm).  Unlike other CPE's, this
+//! one converts everything from the measurement frame (in channel numbers)
+//! into the local frame (in centimeters).
+//-----------------------------------------------------------------------------
+template <typename TrackerTraits>
+LocalPoint PixelCPEFastAlpaka<TrackerTraits>::localPosition(DetParam const& theDetParam,
+                                                            ClusterParam& theClusterParamBase) const {
+  ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
+
+  if (useErrorsFromTemplates_) {
+    errorFromTemplates(theDetParam, theClusterParam, theClusterParam.theCluster->charge());
+  } else {
+    theClusterParam.qBin_ = 0;
+  }
+
+  int q_f_X;  //!< Q of the first  pixel  in X
+  int q_l_X;  //!< Q of the last   pixel  in X
+  int q_f_Y;  //!< Q of the first  pixel  in Y
+  int q_l_Y;  //!< Q of the last   pixel  in Y
+  collect_edge_charges(theClusterParam, q_f_X, q_l_X, q_f_Y, q_l_Y, useErrorsFromTemplates_ && truncatePixelCharge_);
+
+  pixelCPEforDevice::ClusParams cp;
+
+  cp.minRow[0] = theClusterParam.theCluster->minPixelRow();
+  cp.maxRow[0] = theClusterParam.theCluster->maxPixelRow();
+  cp.minCol[0] = theClusterParam.theCluster->minPixelCol();
+  cp.maxCol[0] = theClusterParam.theCluster->maxPixelCol();
+
+  cp.q_f_X[0] = q_f_X;
+  cp.q_l_X[0] = q_l_X;
+  cp.q_f_Y[0] = q_f_Y;
+  cp.q_l_Y[0] = q_l_Y;
+
+  cp.charge[0] = theClusterParam.theCluster->charge();
+  auto& commonParams_ = cpeParams_.m_commonParams;
+  auto& detParams_ = cpeParams_.m_detParams;
+
+  auto ind = theDetParam.theDet->index();
+  pixelCPEforDevice::position<TrackerTraits>(commonParams_, detParams_[ind], cp, 0);
+  auto xPos = cp.xpos[0];
+  auto yPos = cp.ypos[0];
+
+  // set the error  (mind ape....)
+  pixelCPEforDevice::errorFromDB<TrackerTraits>(commonParams_, detParams_[ind], cp, 0);
+  theClusterParam.sigmax = cp.xerr[0];
+  theClusterParam.sigmay = cp.yerr[0];
+
+  LogDebug("PixelCPEFastAlpaka") << " in PixelCPEFastAlpaka:localPosition - pos = " << xPos << " " << yPos << " size "
+                                 << cp.maxRow[0] - cp.minRow[0] << ' ' << cp.maxCol[0] - cp.minCol[0];
+
+  //--- Now put the two together
+  LocalPoint pos_in_local(xPos, yPos);
+  return pos_in_local;
+}
+
+//==============  INFLATED ERROR AND ERRORS FROM DB BELOW  ================
+
+//-------------------------------------------------------------------------
+//  Hit error in the local frame
+//-------------------------------------------------------------------------
+template <typename TrackerTraits>
+LocalError PixelCPEFastAlpaka<TrackerTraits>::localError(DetParam const& theDetParam,
+                                                         ClusterParam& theClusterParamBase) const {
+  ClusterParamGeneric& theClusterParam = static_cast<ClusterParamGeneric&>(theClusterParamBase);
+
+  auto xerr = theClusterParam.sigmax;
+  auto yerr = theClusterParam.sigmay;
+
+  LogDebug("PixelCPEFastAlpaka") << " errors  " << xerr << " " << yerr;
+
+  auto xerr_sq = xerr * xerr;
+  auto yerr_sq = yerr * yerr;
+
+  return LocalError(xerr_sq, 0, yerr_sq);
+}
+
+template <typename TrackerTraits>
+void PixelCPEFastAlpaka<TrackerTraits>::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  // call PixelCPEGenericBase fillPSetDescription to add common rechit errors
+  PixelCPEGenericBase::fillPSetDescription(desc);
+}
+
+template class PixelCPEFastAlpaka<pixelTopology::Phase1>;
+template class PixelCPEFastAlpaka<pixelTopology::Phase2>;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
@@ -1,0 +1,9 @@
+#include "FWCore/Utilities/interface/typelookup.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+using PixelCPEFastParamsPhase1 = pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase1>;
+using PixelCPEFastParamsPhase2 = pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase2>;
+
+TYPELOOKUP_DATA_REG(PixelCPEFastParamsPhase1);
+TYPELOOKUP_DATA_REG(PixelCPEFastParamsPhase2);

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParams.cc
@@ -2,6 +2,8 @@
 #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 
+// Compilation of this file informs framework about the production of the CPEFastParams ESProduct through type lookup data
+
 using PixelCPEFastParamsPhase1 = pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase1>;
 using PixelCPEFastParamsPhase2 = pixelCPEforDevice::PixelCPEFastParams<alpaka_common::DevHost, pixelTopology::Phase2>;
 

--- a/RecoLocalTracker/SiPixelRecHits/src/alpaka/PixelCPEFastParams.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/alpaka/PixelCPEFastParams.cc
@@ -1,0 +1,11 @@
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParams.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+
+template <typename TDev>
+using PixelCPEFastParamsPhase1 = pixelCPEforDevice::PixelCPEFastParams<TDev, pixelTopology::Phase1>;
+template <typename TDev>
+using PixelCPEFastParamsPhase2 = pixelCPEforDevice::PixelCPEFastParams<TDev, pixelTopology::Phase2>;
+
+TYPELOOKUP_ALPAKA_TEMPLATED_DATA_REG(PixelCPEFastParamsPhase1);
+TYPELOOKUP_ALPAKA_TEMPLATED_DATA_REG(PixelCPEFastParamsPhase2);


### PR DESCRIPTION
#### PR description:

Added doxygen descriptions for the `SiPixelRecHitFromSoAAlpaka`, `getHits`, `SiPixelRecHitAlpaka`, and `PixelRecHitGPUKernel` classes, as well as for the `pixelCPEforDevice` namespace. 

The only expected change to the output is fully formatted doxygen class/namespace references upon running doxygen for CMSSW. 

#### PR validation:

No new code has been written, only commented class references adhering to the doxygen standards. The [cmsdoxy](https://github.com/cms-sw/cmsdoxy) script was run to test the output and no errors were observed. The correct doxygen documentation was produced in the test.
