### PR TITLE
remove `onGPU_` member from `caHitNtupletGenerator::AlgoParams`

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGenerator.cc
@@ -43,8 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     //Common Params
     AlgoParams makeCommonParams(edm::ParameterSet const& cfg) {
-      return AlgoParams({cfg.getParameter<bool>("onGPU"),
-                         cfg.getParameter<unsigned int>("minHitsForSharingCut"),
+      return AlgoParams({cfg.getParameter<unsigned int>("minHitsForSharingCut"),
                          cfg.getParameter<bool>("useRiemannFit"),
                          cfg.getParameter<bool>("fitNas4"),
                          cfg.getParameter<bool>("includeJumpingForwardDoublets"),

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
@@ -23,7 +23,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     //Configuration params common to all topologies, for the algorithms
     struct AlgoParams {
-      const bool onGPU_;
       const uint32_t minHitsForSharingCut_;
       const bool useRiemannFit_;
       const bool fitNas4_;


### PR DESCRIPTION
Removes unnecessary parameter from `caHitNtupletGenerator::AlgoParams`.