### PR TITLE
update of HLT customisation for Alpaka pixel reco up to PixelRecHits (can't write RecHits to file)

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -29,7 +29,7 @@ def customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal(process):
     process.hltPixelConsumerCPU.eventProducts = [
         'hltSiPixelClustersCPUSerial',
         'hltSiPixelDigiErrorsCPUSerial',
-        'hltSiPixelRecHitsCPUSerial',
+#        'hltSiPixelRecHitsCPUSerial',
     ]
 
     process.hltPixelConsumerGPU.eventProducts = [
@@ -46,8 +46,8 @@ def customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal(process):
             'keep *Cluster*_hltSiPixelClustersCPUSerial_*_*',
             'keep *_hltSiPixelDigiErrors_*_*',
             'keep *_hltSiPixelDigiErrorsCPUSerial_*_*',
-            'keep *RecHit*_hltSiPixelRecHits_*_*',
-            'keep *RecHit*_hltSiPixelRecHitsCPUSerial_*_*',
+#            'keep *RecHit*_hltSiPixelRecHits_*_*',
+#            'keep *RecHit*_hltSiPixelRecHitsCPUSerial_*_*',
         ]
 
     # empty HLTRecopixelvertexingSequence until we add tracks and vertices
@@ -189,7 +189,6 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
 #    # produces
 #    #  - TkSoADevice
 #    process.hltPixelTracks = cms.EDProducer("CAHitNtupletAlpakaPhase1@alpaka",
-#        onGPU = cms.bool(True),
 #        pixelRecHitSrc = cms.InputTag('hltSiPixelRecHits'),
 #        ptmin = cms.double(0.89999997615814209),
 #        CAThetaCutBarrel = cms.double(0.0020000000949949026),

--- a/HLTrigger/Configuration/test/testHLTWithAlpakaPixelReco.sh
+++ b/HLTrigger/Configuration/test/testHLTWithAlpakaPixelReco.sh
@@ -8,13 +8,15 @@ hltGetConfiguration /frozen/2023/2e34/v1.2/HLT \
   --output all \
   --max-events 100 \
   --paths DQM_PixelReco*,*DQMGPUvsCPU* \
-  --input /store/data/Run2023C/EphemeralHLTPhysics0/RAW/v1/000/368/822/00000/6e1268da-f96a-49f6-a5f0-89933142dd89.root \
+  --input file:/cmsnfsgpu_data/gpu_data/store/data/Run2023C/EphemeralHLTPhysics0/RAW/v1/000/368/822/00000/6e1268da-f96a-49f6-a5f0-89933142dd89.root \
   --customise \
 HLTrigger/Configuration/customizeHLTforPatatrack.customiseHLTforAlpakaPixelReco,\
 HLTrigger/Configuration/customizeHLTforPatatrack.customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal \
   > hlt.py
 
 cat <<EOF >> hlt.py
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 0
 process.hltOutputDQMGPUvsCPU.fileName = '___JOBNAME___.root'
 EOF
 


### PR DESCRIPTION
 - Changed input file to read it from local copy on GPU-dev online machines
 - Added PixelRecHits to EventContent of output file, which currently leads to the following exception
```
----- Begin Fatal Exception 29-Jun-2023 10:25:22 CEST-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)
   Additional Info:
      [a] Fatal Root Error: @SUB=TStreamerInfo::Build
TrackingRecHitAlpakaHost<pixelTopology::Phase1>, unknown type: const pixelCPEforDevice::ParamsOnDeviceT<pixelTopology::Phase1>* cpeParams_


----- End Fatal Exception -------------------------------------------------
```
Reproducer
```
"${CMSSW_BASE}"/src/HLTrigger/Configuration/test/testHLTWithAlpakaPixelReco.sh
```