### PR TITLE
Update the `SiPixelDigisSoA` data formats and dictionaries

### DIFF
--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
@@ -2,22 +2,24 @@
 #define DataFormats_SiPixelDigiSoA_interface_SiPixelDigiErrorsDevice_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-// #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 // #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+// #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
 template <typename TDev>
-class SiPixelDigiErrorsDevice : public PortableDeviceCollection<SiPixelDigiErrorsLayout<>, TDev> {
+class SiPixelDigiErrorsDevice : public PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev> {
 public:
   SiPixelDigiErrorsDevice() = default;
   template <typename TQueue>
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TQueue queue)
-      : PortableDeviceCollection<SiPixelDigiErrorsLayout<>, TDev>(maxFedWords, queue), maxFedWords_(maxFedWords) {
+      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, queue), maxFedWords_(maxFedWords) {
     // printf("SiPixelDigiErrorsDevice\n");
     // data_d = cms::alpakatools::make_device_buffer<SiPixelErrorCompact[]>(queue, maxFedWords);
     // error_d = cms::alpakatools::make_device_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>(queue);
@@ -31,7 +33,7 @@ public:
 
   // Constructor which specifies the SoA size
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TDev const& device)
-      : PortableDeviceCollection<SiPixelDigiErrorsLayout<>, TDev>(maxFedWords, device) {}
+      : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, device) {}
 
   SiPixelDigiErrorsDevice(SiPixelDigiErrorsDevice&&) = default;
   SiPixelDigiErrorsDevice& operator=(SiPixelDigiErrorsDevice&&) = default;

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h
@@ -2,21 +2,23 @@
 #define DataFormats_SiPixelDigiSoA_interface_SiPixelDigiErrorsHost_h
 
 #include <utility>
-#include <alpaka/alpaka.hpp>
-#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-#include "DataFormats/Portable/interface/PortableHostCollection.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
 
-class SiPixelDigiErrorsHost : public PortableHostCollection<SiPixelDigiErrorsLayout<>> {
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
+#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+class SiPixelDigiErrorsHost : public PortableHostCollection<SiPixelDigiErrorsSoA> {
 public:
   SiPixelDigiErrorsHost() = default;
   // template <typename TQueue>
   // explicit SiPixelDigiErrorsHost(int maxFedWords,
   //                                cms::alpakatools::host_buffer<SiPixelErrorCompact[]> data,
   //                                TQueue queue)
-  //     : PortableHostCollection<SiPixelDigiErrorsLayout<>>(maxFedWords, queue), maxFedWords_(maxFedWords) {
+  //     : PortableHostCollection<SiPixelDigiErrorsSoA>(maxFedWords, queue), maxFedWords_(maxFedWords) {
   //   printf("SiPixelDigiErrorsHost\n");
   //   // view().pixelErrors() = std::move(data.data());
   //   // error_h = cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>();
@@ -26,7 +28,7 @@ public:
   // }
   template <typename TQueue>
   explicit SiPixelDigiErrorsHost(int maxFedWords, TQueue queue)
-      : PortableHostCollection<SiPixelDigiErrorsLayout<>>(maxFedWords, queue), maxFedWords_(maxFedWords) {
+      : PortableHostCollection<SiPixelDigiErrorsSoA>(maxFedWords, queue), maxFedWords_(maxFedWords) {
     // printf("SiPixelDigiErrorsHost\n");
     // data_h = cms::alpakatools::make_host_buffer<SiPixelErrorCompact[]>(nErrorWords);
     // error_h = cms::alpakatools::make_host_buffer<cms::alpakatools::SimpleVector<SiPixelErrorCompact>>();

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_SiPixelDigi_SiPixelDigiErrorsLayout_h
-#define DataFormats_SiPixelDigi_SiPixelDigiErrorsLayout_h
+#ifndef DataFormats_SiPixelDigiSoA_interface_SiPixelDigiErrorsSoA_h
+#define DataFormats_SiPixelDigiSoA_interface_SiPixelDigiErrorsSoA_h
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
@@ -12,8 +12,8 @@ GENERATE_SOA_LAYOUT(SiPixelDigiErrorsLayout,
                     SOA_SCALAR(uint32_t, size))  //,
 // SOA_SCALAR(SiPixelErrorCompactVec, pixelErrorsVec))
 
-using SiPixelDigiErrorsLayoutSoA = SiPixelDigiErrorsLayout<>;
-using SiPixelDigiErrorsLayoutSoAView = SiPixelDigiErrorsLayout<>::View;
-using SiPixelDigiErrorsLayoutSoAConstView = SiPixelDigiErrorsLayout<>::ConstView;
+using SiPixelDigiErrorsSoA = SiPixelDigiErrorsLayout<>;
+using SiPixelDigiErrorsSoAView = SiPixelDigiErrorsSoA::View;
+using SiPixelDigiErrorsSoAConstView = SiPixelDigiErrorsSoA::ConstView;
 
-#endif  // DataFormats_SiPixelDigi_SiPixelDigisErrorLayout_h
+#endif  // DataFormats_SiPixelDigiSoA_interface_SiPixelDigiErrorsSoA_h

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
@@ -2,24 +2,25 @@
 #define DataFormats_SiPixelDigiSoA_interface_SiPixelDigisDevice_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
 #include "DataFormats/Portable/interface/PortableDeviceCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 template <typename TDev>
-class SiPixelDigisDevice : public PortableDeviceCollection<SiPixelDigisLayout<>, TDev> {
+class SiPixelDigisDevice : public PortableDeviceCollection<SiPixelDigisSoAv2, TDev> {
 public:
   SiPixelDigisDevice() = default;
   template <typename TQueue>
   explicit SiPixelDigisDevice(size_t maxFedWords, TQueue queue)
-      : PortableDeviceCollection<SiPixelDigisLayout<>, TDev>(maxFedWords + 1, queue) {}
+      : PortableDeviceCollection<SiPixelDigisSoAv2, TDev>(maxFedWords + 1, queue) {}
   ~SiPixelDigisDevice() = default;
 
   // Constructor which specifies the SoA size
   explicit SiPixelDigisDevice(size_t maxFedWords, TDev const &device)
-      : PortableDeviceCollection<SiPixelDigisLayout<>, TDev>(maxFedWords + 1, device) {}
+      : PortableDeviceCollection<SiPixelDigisSoAv2, TDev>(maxFedWords + 1, device) {}
 
   SiPixelDigisDevice(SiPixelDigisDevice &&) = default;
   SiPixelDigisDevice &operator=(SiPixelDigisDevice &&) = default;

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
@@ -1,20 +1,18 @@
 #ifndef DataFormats_SiPixelDigiSoA_interface_SiPixelDigisHost_h
 #define DataFormats_SiPixelDigiSoA_interface_SiPixelDigisHost_h
 
-#include <alpaka/alpaka.hpp>
 #include "DataFormats/Portable/interface/PortableHostCollection.h"
-
-#include "SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 
 // TODO: The class is created via inheritance of the PortableDeviceCollection.
 // This is generally discouraged, and should be done via composition.
 // See: https://github.com/cms-sw/cmssw/pull/40465#discussion_r1067364306
-class SiPixelDigisHost : public PortableHostCollection<SiPixelDigisLayout<>> {
+class SiPixelDigisHost : public PortableHostCollection<SiPixelDigisSoAv2> {
 public:
   SiPixelDigisHost() = default;
   template <typename TQueue>
   explicit SiPixelDigisHost(size_t maxFedWords, TQueue queue)
-      : PortableHostCollection<SiPixelDigisLayout<>>(maxFedWords + 1, queue) {}
+      : PortableHostCollection<SiPixelDigisSoAv2>(maxFedWords + 1, queue) {}
   ~SiPixelDigisHost() = default;
 
   SiPixelDigisHost(SiPixelDigisHost &&) = default;

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_SiPixelDigi_SiPixelDigisLayout_h
-#define DataFormats_SiPixelDigi_SiPixelDigisLayout_h
+#ifndef DataFormats_SiPixelDigiSoA_interface_SiPixelDigisSoAv2_h
+#define DataFormats_SiPixelDigiSoA_interface_SiPixelDigisSoAv2_h
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 
@@ -12,8 +12,8 @@ GENERATE_SOA_LAYOUT(SiPixelDigisLayout,
                     SOA_COLUMN(uint16_t, yy),
                     SOA_COLUMN(uint16_t, moduleId))
 
-using SiPixelDigisLayoutSoA = SiPixelDigisLayout<>;
-using SiPixelDigisLayoutSoAView = SiPixelDigisLayout<>::View;
-using SiPixelDigisLayoutSoAConstView = SiPixelDigisLayout<>::ConstView;
+using SiPixelDigisSoAv2 = SiPixelDigisLayout<>;
+using SiPixelDigisSoAv2View = SiPixelDigisSoAv2::View;
+using SiPixelDigisSoAv2ConstView = SiPixelDigisSoAv2::ConstView;
 
-#endif  // DataFormats_SiPixelDigi_SiPixelDigisLayout_h
+#endif  // DataFormats_SiPixelDigiSoA_interface_SiPixelDigisSoAv2_h

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h
@@ -2,15 +2,15 @@
 #define DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigiErrorsCollection_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
+
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsUtilities.h"
-#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
+//#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsUtilities.h"
+//#include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-
-#include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h
@@ -19,14 +19,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #else
   using SiPixelDigiErrorsCollection = SiPixelDigiErrorsDevice<Device>;
 #endif
-  using SiPixelDigiErrorsSoA = SiPixelDigiErrorsCollection;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 namespace cms::alpakatools {
   template <>
-  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsSoA> {
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsCollection> {
     template <typename TQueue>
-    static auto copyAsync(TQueue& queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsSoA const& srcData) {
+    static auto copyAsync(TQueue& queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigiErrorsCollection const& srcData) {
       // auto error_vector_d = srcData.error_vector();
       // auto error_data_h = cms::alpakatools::make_host_buffer<SiPixelErrorCompact[]>(error_vector_d.capacity());
       // auto error_data_d = srcData.error_data();

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsUtilities.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsUtilities.h
@@ -1,28 +1,28 @@
 #ifndef DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigiErrorsUtilities_h
 #define DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigiErrorsUtilities_h
 
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 
 // ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static constexpr SiPixelErrorCompactVec* error(
-//     SiPixelDigiErrorsLayoutSoAView& errors) {
+//     SiPixelDigiErrorsSoAView& errors) {
 //   return (&errors.pixelErrorsVec());
 // }
 // ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static constexpr SiPixelErrorCompactVec const* error(
-//     const SiPixelDigiErrorsLayoutSoAConstView& errors) {
+//     const SiPixelDigiErrorsSoAConstView& errors) {
 //   return (&errors.pixelErrorsVec());
 // }
 // ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static constexpr SiPixelErrorCompact& error_data(
-//     SiPixelDigiErrorsLayoutSoAView& errors) {
+//     SiPixelDigiErrorsSoAView& errors) {
 //   return (*errors.pixelErrors());
 // }
 // ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static constexpr SiPixelErrorCompact const& error_data(
-//     const SiPixelDigiErrorsLayoutSoAConstView& errors) {
+//     const SiPixelDigiErrorsSoAConstView& errors) {
 //   return (*errors.pixelErrors());
 // }
 // ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static constexpr SiPixelErrorCompactVec& error_vector(
-//     SiPixelDigiErrorsLayoutSoAView& errors) {
+//     SiPixelDigiErrorsSoAView& errors) {
 //   return (errors.pixelErrorsVec());
 // }
 

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h
@@ -1,14 +1,16 @@
-#ifndef DataFormats_SiPixelDigi_interface_alpaka_SiPixelDigisCollection_h
-#define DataFormats_SiPixelDigi_interface_alpaka_SiPixelDigisCollection_h
+#ifndef DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigisCollection_h
+#define DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigisCollection_h
 
 #include <cstdint>
+
 #include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+
+//#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+//#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -16,16 +18,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using SiPixelDigisCollection = SiPixelDigisHost;
 #else
   using SiPixelDigisCollection = SiPixelDigisDevice<Device>;
-
 #endif
-  using SiPixelDigisSoA = SiPixelDigisCollection;
+
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 namespace cms::alpakatools {
   template <>
-  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisSoA> {
+  struct CopyToHost<ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisCollection> {
     template <typename TQueue>
-    static auto copyAsync(TQueue &queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisSoA const &srcData) {
+    static auto copyAsync(TQueue &queue, ALPAKA_ACCELERATOR_NAMESPACE::SiPixelDigisCollection const &srcData) {
       SiPixelDigisHost dstData(srcData.view().metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       dstData.setNModulesDigis(srcData.nModules(), srcData.nDigis());
@@ -34,5 +35,4 @@ namespace cms::alpakatools {
   };
 }  // namespace cms::alpakatools
 
-// }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-#endif  // DataFormats_SiPixelDigi_interface_alpaka_SiPixelDigisCollection_h
+#endif  // DataFormats_SiPixelDigiSoA_interface_alpaka_SiPixelDigisCollection_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
@@ -3,9 +3,9 @@
 
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
 

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda.h
@@ -1,12 +1,12 @@
 #ifndef DataFormats_SiPixelDigiSoA_Alpaka_Classes_cuda_h
 #define DataFormats_SiPixelDigiSoA_Alpaka_Classes_cuda_h
 
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DeviceProduct.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
 
 #endif  // DataFormats_SiPixelDigiSoA_src_alpaka_classes_cuda_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
@@ -4,8 +4,10 @@
   <class name="edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>>" persistent="false"/>
 
-  <class name="PortableDeviceCollection<SiPixelDigiErrorsLayoutSoA, alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>" persistent="false"/>
-  <class name="SiPixelDigiErrorsDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>" persistent="false"/>
-  <class name="edm::DeviceProduct<SiPixelDigiErrorsDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>" persistent="false"/>
-  <class name="edm::Wrapper<edm::DeviceProduct<SiPixelDigiErrorsDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>>" persistent="false"/>
+  <!-- SiPixelDigiErrors-related collections -->
+  <class name="alpaka_cuda_async::PortableCollection<SiPixelDigiErrorsSoA>" persistent="false"/>
+  <!-- SiPixelDigiErrorsCollection inherits from PortableCollection<SiPixelDigiErrorsSoA> -->
+  <class name="alpaka_cuda_async::SiPixelDigiErrorsCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::SiPixelDigiErrorsCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::SiPixelDigiErrorsCollection>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_cuda_def.xml
@@ -1,8 +1,10 @@
 <lcgdict>
-  <class name="PortableDeviceCollection<SiPixelDigisLayoutSoA, alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>" persistent="false"/>
-  <class name="SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>" persistent="false"/>
-  <class name="edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>" persistent="false"/>
-  <class name="edm::Wrapper<edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiCudaRt>>>>" persistent="false"/>
+  <!-- SiPixelDigisSoAv2-related collections -->
+  <class name="alpaka_cuda_async::PortableCollection<SiPixelDigisSoAv2>" persistent="false"/>
+  <!-- SiPixelDigisCollection inherits from PortableCollection<SiPixelDigisSoAv2> -->
+  <class name="alpaka_cuda_async::SiPixelDigisCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::SiPixelDigisCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::SiPixelDigisCollection>>" persistent="false"/>
 
   <!-- SiPixelDigiErrors-related collections -->
   <class name="alpaka_cuda_async::PortableCollection<SiPixelDigiErrorsSoA>" persistent="false"/>

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
@@ -1,12 +1,12 @@
-#ifndef DataFormats_SiPixelDigisoA_Alpaka_Classes_rocm_h
-#define DataFormats_SiPixelDigisoA_Alpaka_Classes_rocm_h
+#ifndef DataFormats_SiPixelDigiSoA_Alpaka_Classes_cuda_h
+#define DataFormats_SiPixelDigiSoA_Alpaka_Classes_cuda_h
 
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/DeviceProduct.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
 
-#endif  // DataFormats_SiPixelDigiSoA_src_alpaka_classes_rocm_h
+#endif  // DataFormats_SiPixelDigiSoA_src_alpaka_classes_cuda_h

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm.h
@@ -3,9 +3,10 @@
 
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
 

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
@@ -1,4 +1,13 @@
 <lcgdict>
-  <class name="alpaka_rocm_async::SiPixelDigisSoA" persistent="false"/>
-  <class name="edm::Wrapper<alpaka_rocm_async::SiPixelDigisSoA>" persistent="false"/>
+  <class name="PortableDeviceCollection<SiPixelDigisLayoutSoA, alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>" persistent="false"/>
+  <class name="SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>" persistent="false"/>
+  <class name="edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>>>" persistent="false"/>
+
+  <!-- SiPixelDigiErrors-related collections -->
+  <class name="alpaka_rocm_async::PortableCollection<SiPixelDigiErrorsSoA>" persistent="false"/>
+  <!-- SiPixelDigiErrorsCollection inherits from PortableCollection<SiPixelDigiErrorsSoA> -->
+  <class name="alpaka_rocm_async::SiPixelDigiErrorsCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::SiPixelDigiErrorsCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::SiPixelDigiErrorsCollection>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/alpaka/classes_rocm_def.xml
@@ -1,8 +1,10 @@
 <lcgdict>
-  <class name="PortableDeviceCollection<SiPixelDigisLayoutSoA, alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>" persistent="false"/>
-  <class name="SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>" persistent="false"/>
-  <class name="edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>>" persistent="false"/>
-  <class name="edm::Wrapper<edm::DeviceProduct<SiPixelDigisDevice<alpaka::DevUniformCudaHipRt<alpaka::ApiHipRt>>>>" persistent="false"/>
+  <!-- SiPixelDigisSoAv2-related collections -->
+  <class name="alpaka_rocm_async::PortableCollection<SiPixelDigisSoAv2>" persistent="false"/>
+  <!-- SiPixelDigisCollection inherits from PortableCollection<SiPixelDigisSoAv2> -->
+  <class name="alpaka_rocm_async::SiPixelDigisCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::SiPixelDigisCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::SiPixelDigisCollection>>" persistent="false"/>
 
   <!-- SiPixelDigiErrors-related collections -->
   <class name="alpaka_rocm_async::PortableCollection<SiPixelDigiErrorsSoA>" persistent="false"/>

--- a/DataFormats/SiPixelDigiSoA/src/classes.h
+++ b/DataFormats/SiPixelDigiSoA/src/classes.h
@@ -2,9 +2,9 @@
 #define DataFormats_SiPixelDigisSoA_src_classes_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 
 #endif  // DataFormats_SiPixelClusterSoA_src_classes_h

--- a/DataFormats/SiPixelDigiSoA/src/classes.h
+++ b/DataFormats/SiPixelDigiSoA/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
 
 #endif  // DataFormats_SiPixelClusterSoA_src_classes_h

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -17,21 +17,24 @@
   <class name="SiPixelDigisHost"/>
   <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>
 
-  <class name="SiPixelDigiErrorsLayoutSoA"/>
-  <class name="SiPixelDigiErrorsLayoutSoA::View"/>
-  <class name="PortableHostCollection<SiPixelDigiErrorsLayoutSoA>"/>
+  <!-- SiPixelDigiErrors-related collections -->
+  <class name="SiPixelDigiErrorsSoA"/>
+  <class name="SiPixelDigiErrorsSoA::View"/>
+  <class name="PortableHostCollection<SiPixelDigiErrorsSoA>"/>
   <read
-    sourceClass="PortableHostCollection<SiPixelDigiErrorsLayoutSoA>"
-    targetClass="PortableHostCollection<SiPixelDigiErrorsLayoutSoA>"
+    sourceClass="PortableHostCollection<SiPixelDigiErrorsSoA>"
+    targetClass="PortableHostCollection<SiPixelDigiErrorsSoA>"
     version="[1-]"
-    source="SiPixelDigiErrorsLayoutSoA layout_;"
+    source="SiPixelDigiErrorsSoA layout_;"
     target="buffer_"
     embed="false">
   <![CDATA[
-    PortableHostCollection<SiPixelDigiErrorsLayoutSoA>::ROOTReadStreamer(newObj, onfile.layout_);
+    PortableHostCollection<SiPixelDigiErrorsSoA>::ROOTReadStreamer(newObj, onfile.layout_);
   ]]>
   </read> 
+  <!-- SiPixelDigiErrorsHost inherits from PortableHostCollection<SiPixelDigiErrorsSoA> -->
   <class name="SiPixelDigiErrorsHost"/>
   <class name="edm::Wrapper<SiPixelDigiErrorsHost>" splitLevel="0"/>
+
   <!-- <class name="map<unsigned int,vector<SiPixelRawDataError> >"/> -->
 </lcgdict>

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -1,16 +1,16 @@
 <lcgdict>
-  <class name="SiPixelDigisLayoutSoA"/>
-  <class name="SiPixelDigisLayoutSoA::View"/>
-  <class name="PortableHostCollection<SiPixelDigisLayoutSoA>"/>
+  <class name="SiPixelDigisSoAv2"/>
+  <class name="SiPixelDigisSoAv2::View"/>
+  <class name="PortableHostCollection<SiPixelDigisSoAv2>"/>
   <read
-    sourceClass="PortableHostCollection<SiPixelDigisLayoutSoA>"
-    targetClass="PortableHostCollection<SiPixelDigisLayoutSoA>"
+    sourceClass="PortableHostCollection<SiPixelDigisSoAv2>"
+    targetClass="PortableHostCollection<SiPixelDigisSoAv2>"
     version="[1-]"
-    source="SiPixelDigisLayoutSoA layout_;"
+    source="SiPixelDigisSoAv2 layout_;"
     target="buffer_"
     embed="false">
   <![CDATA[
-    PortableHostCollection<SiPixelDigisLayoutSoA>::ROOTReadStreamer(newObj, onfile.layout_);
+    PortableHostCollection<SiPixelDigisSoAv2>::ROOTReadStreamer(newObj, onfile.layout_);
   ]]>
   </read>
 

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.cc
@@ -2,9 +2,9 @@
 #include <unistd.h>
 
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsCollection.h"
 
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
@@ -18,7 +18,7 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace testDigisSoA {
 
-    void runKernels(SiPixelDigiErrorsLayoutSoAView digiErrors_view, Queue& queue);
+    void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue);
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
@@ -31,7 +31,7 @@ int main() {
   {
     // Instantiate tracks on device. PortableDeviceCollection allocates
     // SoA on device automatically.
-    SiPixelDigiErrorsSoA digiErrors_d(1000, queue);
+    SiPixelDigiErrorsCollection digiErrors_d(1000, queue);
     testDigisSoA::runKernels(digiErrors_d.view(), queue);
 
     // Instantate tracks on host. This is where the data will be

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
@@ -15,7 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     class TestFillKernel {
     public:
       template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsLayoutSoAView digiErrors_view) const {
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAView digiErrors_view) const {
         for (uint32_t j : elements_with_stride(acc, digiErrors_view.metadata().size())) {
           digiErrors_view[j].pixelErrors().rawId = j;
           digiErrors_view[j].pixelErrors().word = j;
@@ -28,7 +28,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     class TestVerifyKernel {
     public:
       template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsLayoutSoAConstView digiErrors_view) const {
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAConstView digiErrors_view) const {
         for (uint32_t j : elements_with_stride(acc, digiErrors_view.metadata().size())) {
           assert(digiErrors_view[j].pixelErrors().rawId == j);
           assert(digiErrors_view[j].pixelErrors().word == j);
@@ -38,7 +38,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     };
 
-    void runKernels(SiPixelDigiErrorsLayoutSoAView digiErrors_view, Queue& queue) {
+    void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue) {
       uint32_t items = 64;
       uint32_t groups = divide_up_by(digiErrors_view.metadata().size(), items);
       auto workDiv = make_workdiv<Acc1D>(groups, items);

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
@@ -1,24 +1,25 @@
-#include <alpaka/alpaka.hpp>
 #include <unistd.h>
 
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include <alpaka/alpaka.hpp>
 
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace testDigisSoA {
 
-    void runKernels(SiPixelDigisLayoutSoAView digis_view, Queue& queue);
+    void runKernels(SiPixelDigisSoAv2View digis_view, Queue& queue);
+
   }
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
@@ -31,7 +32,7 @@ int main() {
   {
     // Instantiate tracks on device. PortableDeviceCollection allocates
     // SoA on device automatically.
-    SiPixelDigisSoA digis_d(1000, queue);
+    SiPixelDigisCollection digis_d(1000, queue);
     testDigisSoA::runKernels(digis_d.view(), queue);
 
     // Instantate tracks on host. This is where the data will be

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
@@ -14,7 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     class TestFillKernel {
     public:
       template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisLayoutSoAView digi_view) const {
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAv2View digi_view) const {
         for (int32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
           digi_view[j].clus() = j;
           digi_view[j].rawIdArr() = j * 2;
@@ -27,7 +27,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     class TestVerifyKernel {
     public:
       template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisLayoutSoAConstView digi_view) const {
+      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAv2ConstView digi_view) const {
         for (uint32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
           assert(digi_view[j].clus() == int(j));
           assert(digi_view[j].rawIdArr() == j * 2);
@@ -37,7 +37,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     };
 
-    void runKernels(SiPixelDigisLayoutSoAView digi_view, Queue& queue) {
+    void runKernels(SiPixelDigisSoAv2View digi_view, Queue& queue) {
       uint32_t items = 64;
       uint32_t groups = divide_up_by(digi_view.metadata().size(), items);
       auto workDiv = make_workdiv<Acc1D>(groups, items);

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiErrorsSoAFromAlpaka.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiErrorsSoAFromAlpaka.cc
@@ -1,16 +1,16 @@
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsUtilities.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorsSoA.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 
 class SiPixelDigiErrorsSoAFromAlpaka : public edm::stream::EDProducer<> {
 public:

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -111,7 +111,7 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     # produces (* optional)
     #  - SiPixelClustersSoA
     #  - SiPixelDigisSoA
-    #  - SiPixelDigiErrorsSoA *
+    #  - SiPixelDigiErrorsCollection *
     #  - SiPixelFormatterErrors *
     process.hltSiPixelClusters = cms.EDProducer('SiPixelRawToCluster@alpaka',
         isRun2 = cms.bool(False),

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -110,7 +110,7 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     #  - FEDRawDataCollection
     # produces (* optional)
     #  - SiPixelClustersSoA
-    #  - SiPixelDigisSoA
+    #  - SiPixelDigisCollection
     #  - SiPixelDigiErrorsCollection *
     #  - SiPixelFormatterErrors *
     process.hltSiPixelClusters = cms.EDProducer('SiPixelRawToCluster@alpaka',
@@ -164,7 +164,7 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     # consumes
     #  - BeamSpotDeviceProduct
     #  - SiPixelClustersSoA
-    #  - SiPixelDigisSoA
+    #  - SiPixelDigisCollection
     # produces
     #  - TrackingRecHitAlpakaCollection<TrackerTraits>
     process.hltSiPixelRecHits = cms.EDProducer("SiPixelRecHitAlpakaPhase1@alpaka",

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelDigisClustersFromSoA.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-#include "DataFormats/SiPixelDigi/interface/SiPixelDigisSoA.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,9 +14,8 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 // local include(s)
 #include "PixelClusterizerBase.h"
@@ -35,7 +34,6 @@ private:
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
 
-  // edm::EDGetTokenT<SiPixelDigisSoA> digiGetToken_;
   edm::EDGetTokenT<SiPixelDigisHost> digiGetToken_;
 
   edm::EDPutTokenT<edm::DetSetVector<PixelDigi>> digiPutToken_;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <type_traits>
+
 #include <alpaka/alpaka.hpp>
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLTLayout.h"
@@ -12,11 +13,11 @@
 #include "CondFormats/SiPixelObjects/interface/alpaka/SiPixelGainCalibrationForHLTUtilities.h"
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
-#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/CalibPixel.h
@@ -14,7 +14,7 @@
 #include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
@@ -42,7 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       template <typename TAcc>
       ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                     bool isRun2,
-                                    SiPixelDigisLayoutSoAView view,
+                                    SiPixelDigisSoAv2View view,
                                     SiPixelClustersSoAView clus_view,
                                     const SiPixelGainCalibrationForHLTSoAConstView gains,
                                     int numElements) const {
@@ -93,7 +93,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // struct calibDigisPhase2 {
     //   template <typename TAcc>
     //   ALPAKA_FN_ACC void operator()(const TAcc& acc,
-    //                                 SiPixelDigisLayoutSoAView& view,
+    //                                 SiPixelDigisSoAv2View& view,
     //                                 SiPixelClustersSoAView& clus_view,
     //                                 int numElements
     //   ) const {

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/ClusterChargeCut.h
@@ -4,12 +4,12 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoAv2.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/prefixScan.h"
-#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterThresholds.h"
-#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
-#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisLayout.h"
 
 // namespace ALPAKA_ACCELERATOR_NAMESPACE {
 namespace pixelClustering {
@@ -19,7 +19,7 @@ namespace pixelClustering {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(
         const TAcc& acc,
-        SiPixelDigisLayoutSoAView digi_view,
+        SiPixelDigisSoAv2View digi_view,
         SiPixelClustersSoAView clus_view,
         SiPixelClusterThresholds
             clusterThresholds,  // charge cut on cluster in electrons (for layer 1 and for other layers)

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h
@@ -87,7 +87,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     struct countModules {
       template <typename TAcc>
       ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                    SiPixelDigisLayoutSoAView digi_view,
+                                    SiPixelDigisSoAv2View digi_view,
                                     SiPixelClustersSoAView clus_view,
                                     const unsigned int numElements) const {
         [[maybe_unused]] constexpr int nMaxModules = TrackerTraits::numberOfModules;
@@ -114,7 +114,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     struct findClus {
       template <typename TAcc>
       ALPAKA_FN_ACC void operator()(const TAcc& acc,
-                                    SiPixelDigisLayoutSoAView digi_view,
+                                    SiPixelDigisSoAv2View digi_view,
                                     SiPixelClustersSoAView clus_view,
                                     const unsigned int numElements) const {
         const uint32_t blockIdx(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -66,7 +66,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
     const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
 
-    device::EDPutToken<SiPixelDigisSoA> digiPutToken_;
+    device::EDPutToken<SiPixelDigisCollection> digiPutToken_;
     device::EDPutToken<SiPixelDigiErrorsCollection> digiErrorPutToken_;
     device::EDPutToken<SiPixelClustersCollection> clusterPutToken_;
 
@@ -76,7 +76,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const SiPixelClusterThresholds clusterThresholds_;
     uint32_t nDigis_ = 0;
 
-    SiPixelDigisSoA digis_d;
+    SiPixelDigisCollection digis_d;
   };
 
   SiPixelPhase2DigiToCluster::SiPixelPhase2DigiToCluster(const edm::ParameterSet& iConfig)
@@ -140,7 +140,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       }
     }
 
-    digis_d = SiPixelDigisSoA(nDigis, iEvent.queue());
+    digis_d = SiPixelDigisCollection(nDigis, iEvent.queue());
     alpaka::memcpy(iEvent.queue(), digis_d.buffer(), digis_h.buffer());
 
     Algo_.makePhase2ClustersAsync(clusterThresholds_, digis_d.view(), nDigis, iEvent.queue());

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelPhase2DigiToCluster.cc
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
 
     device::EDPutToken<SiPixelDigisSoA> digiPutToken_;
-    device::EDPutToken<SiPixelDigiErrorsSoA> digiErrorPutToken_;
+    device::EDPutToken<SiPixelDigiErrorsCollection> digiErrorPutToken_;
     device::EDPutToken<SiPixelClustersCollection> clusterPutToken_;
 
     pixelDetails::SiPixelRawToClusterKernel Algo_;
@@ -152,7 +152,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       iEvent.emplace(digiPutToken_, std::move(digis_d));
       iEvent.emplace(clusterPutToken_, std::move(clusters_d));
       if (includeErrors_) {
-        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsSoA());
+        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsCollection());
       }
       return;
     }

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -74,7 +74,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDGetTokenT<FEDRawDataCollection> rawGetToken_;
     edm::EDPutTokenT<SiPixelFormatterErrors> fmtErrorToken_;
     device::EDPutToken<SiPixelDigisSoA> digiPutToken_;
-    device::EDPutToken<SiPixelDigiErrorsSoA> digiErrorPutToken_;
+    device::EDPutToken<SiPixelDigiErrorsCollection> digiErrorPutToken_;
     device::EDPutToken<SiPixelClustersCollection> clusterPutToken_;
 
     edm::ESWatcher<SiPixelFedCablingMapRcd> recordWatcher_;
@@ -287,7 +287,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       iEvent.emplace(digiPutToken_, std::move(digis_d));
       iEvent.emplace(clusterPutToken_, std::move(clusters_d));
       if (includeErrors_) {
-        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsSoA());
+        iEvent.emplace(digiErrorPutToken_, SiPixelDigiErrorsCollection());
         iEvent.emplace(fmtErrorToken_, std::move(errors_));
       }
       return;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -73,7 +73,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     edm::EDGetTokenT<FEDRawDataCollection> rawGetToken_;
     edm::EDPutTokenT<SiPixelFormatterErrors> fmtErrorToken_;
-    device::EDPutToken<SiPixelDigisSoA> digiPutToken_;
+    device::EDPutToken<SiPixelDigisCollection> digiPutToken_;
     device::EDPutToken<SiPixelDigiErrorsCollection> digiErrorPutToken_;
     device::EDPutToken<SiPixelClustersCollection> clusterPutToken_;
 
@@ -282,7 +282,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // still used downstream to initialize TrackingRecHitSoADevice. If there
       // are no valid pointers to clusters' Collection columns, instantiation
       // of TrackingRecHits fail. Example: workflow 11604.0
-      SiPixelDigisSoA digis_d = SiPixelDigisSoA(nDigis_, iEvent.queue());
+      SiPixelDigisCollection digis_d = SiPixelDigisCollection(nDigis_, iEvent.queue());
       SiPixelClustersCollection clusters_d{pixelTopology::Phase1::numberOfModules, iEvent.queue()};
       iEvent.emplace(digiPutToken_, std::move(digis_d));
       iEvent.emplace(clusterPutToken_, std::move(clusters_d));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -373,7 +373,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                     // uint32_t *rawIdArr,
                                     // uint16_t *moduleId,
                                     // cms::alpakatools::SimpleVector<SiPixelErrorCompact> *err,
-                                    SiPixelDigiErrorsLayoutSoAView err,
+                                    SiPixelDigiErrorsSoAView err,
                                     bool useQualityInfo,
                                     bool includeErrors,
                                     bool debug) const {
@@ -611,8 +611,7 @@ namespace pixelDetails {
             }
           }
         }});
-      
-      
+
 #ifndef NDEBUG
       [[maybe_unused]] const uint32_t blockIdxLocal(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u]);
       ALPAKA_ASSERT_OFFLOAD(0 == blockIdxLocal);
@@ -745,7 +744,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       digis_d = SiPixelDigisSoA(wordCounter, queue);
       if (includeErrors) {
         // std::cout << errors.begin()->first << " - " << (errors.begin()->second).size() << std::endl;
-        digiErrors_d = SiPixelDigiErrorsSoA(wordCounter, queue);  // std::move(errors), queue);
+        digiErrors_d = SiPixelDigiErrorsCollection(wordCounter, queue);  // std::move(errors), queue);
       }
       clusters_d = SiPixelClustersCollection(numberOfModules, queue);
       if (wordCounter)  // protect in case of empty event....

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -36,6 +36,7 @@
 #include "ClusterChargeCut.h"
 #include "PixelClustering.h"
 #include "SiPixelRawToClusterKernel.h"
+
 #define GPU_DEBUG
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   namespace pixelDetails {
@@ -365,7 +366,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                     const uint32_t wordCounter,
                                     const uint32_t *word,
                                     const uint8_t *fedIds,
-                                    SiPixelDigisLayoutSoAView digisView,
+                                    SiPixelDigisSoAv2View digisView,
                                     // uint16_t *xx,
                                     // uint16_t *yy,
                                     // uint16_t *adc,
@@ -741,7 +742,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::cout << "decoding " << wordCounter << " digis." << std::endl;
 #endif
       constexpr int numberOfModules = pixelTopology::Phase1::numberOfModules;
-      digis_d = SiPixelDigisSoA(wordCounter, queue);
+      digis_d = SiPixelDigisCollection(wordCounter, queue);
       if (includeErrors) {
         // std::cout << errors.begin()->first << " - " << (errors.begin()->second).size() << std::endl;
         digiErrors_d = SiPixelDigiErrorsCollection(wordCounter, queue);  // std::move(errors), queue);
@@ -899,14 +900,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     void SiPixelRawToClusterKernel::makePhase2ClustersAsync(const SiPixelClusterThresholds clusterThresholds,
-                                                            SiPixelDigisLayoutSoAView &digis_view,
+                                                            SiPixelDigisSoAv2View &digis_view,
                                                             const uint32_t numDigis,
                                                             Queue &queue) {
       using namespace pixelClustering;
       using pixelTopology::Phase2;
       nDigis = numDigis;
       constexpr int numberOfModules = pixelTopology::Phase2::numberOfModules;
-      // digis_d = SiPixelDigisSoA(numDigis, queue);
+      // digis_d = SiPixelDigisCollection(numDigis, queue);
 
       // alpaka::memcpy(queue, digis_d->view(), digis_h_view);
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -164,17 +164,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                              Queue& queue);
 
       void makePhase2ClustersAsync(const SiPixelClusterThresholds clusterThresholds,
-                                   SiPixelDigisLayoutSoAView& digis_view,
+                                   SiPixelDigisSoAv2View& digis_view,
                                    const uint32_t numDigis,
                                    Queue& queue);
 
-      // std::pair<SiPixelDigisSoA, SiPixelClustersDevice> getResults() {
+      // std::pair<SiPixelDigisCollection, SiPixelClustersDevice> getResults() {
       //   digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
       //   clusters_d->setNClusters(nModules_Clusters_h[1], nModules_Clusters_h[2]);
       //   return std::make_pair(std::move(*digis_d), std::move(*clusters_d));
       // }
 
-      SiPixelDigisSoA&& getDigis() {
+      SiPixelDigisCollection&& getDigis() {
         digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
         return std::move(*digis_d);
       }
@@ -191,7 +191,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       // Data to be put in the event
       cms::alpakatools::host_buffer<uint32_t[]> nModules_Clusters_h;
-      std::optional<SiPixelDigisSoA> digis_d;
+      std::optional<SiPixelDigisCollection> digis_d;
       std::optional<SiPixelClustersCollection> clusters_d;
       std::optional<SiPixelDigiErrorsCollection> digiErrors_d;
     };

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -184,7 +184,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         return std::move(*clusters_d);
       }
 
-      SiPixelDigiErrorsSoA&& getErrors() { return std::move(*digiErrors_d); }
+      SiPixelDigiErrorsCollection&& getErrors() { return std::move(*digiErrors_d); }
 
     private:
       uint32_t nDigis = 0;
@@ -193,7 +193,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       cms::alpakatools::host_buffer<uint32_t[]> nModules_Clusters_h;
       std::optional<SiPixelDigisSoA> digis_d;
       std::optional<SiPixelClustersCollection> clusters_d;
-      std::optional<SiPixelDigiErrorsSoA> digiErrors_d;
+      std::optional<SiPixelDigiErrorsCollection> digiErrors_d;
     };
 
   }  // namespace pixelDetails

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.dev.cc
@@ -48,7 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     template <typename TrackerTraits>
     TrackingRecHitAlpakaCollection<TrackerTraits> PixelRecHitGPUKernel<TrackerTraits>::makeHitsAsync(
-        SiPixelDigisSoA const& digis_d,
+        SiPixelDigisCollection const& digis_d,
         SiPixelClustersCollection const& clusters_d,
         BeamSpotPOD const* bs_d,
         pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* cpeParams,

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitGPUKernel.h
@@ -33,7 +33,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       using ParamsOnGPU = pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits>;
 
-      TrackingRecHitAlpakaCollection<TrackerTraits> makeHitsAsync(SiPixelDigisSoA const& digis_d,
+      TrackingRecHitAlpakaCollection<TrackerTraits> makeHitsAsync(SiPixelDigisCollection const& digis_d,
                                                               SiPixelClustersCollection const& clusters_d,
                                                               BeamSpotPOD const* bs_d,
                                                               ParamsOnGPU const* cpeParams,

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -50,7 +50,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const device::ESGetToken<PixelCPEFastParams<TrackerTraits>, PixelCPEFastParamsRecord> cpeToken_;
     const device::EDGetToken<BeamSpotDeviceProduct> tBeamSpot;
     const device::EDGetToken<SiPixelClustersCollection> tokenClusters_;
-    const device::EDGetToken<SiPixelDigisSoA> tokenDigi_;
+    const device::EDGetToken<SiPixelDigisCollection> tokenDigi_;
     const device::EDPutToken<TrackingRecHitAlpakaCollection<TrackerTraits>> tokenHit_;
 
     const pixelgpudetails::PixelRecHitGPUKernel<TrackerTraits> gpuAlgo_;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/pixelRecHits.h
@@ -30,7 +30,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                     pixelCPEforDevice::ParamsOnDeviceT<TrackerTraits> const* __restrict__ cpeParams,
                                     BeamSpotPOD const* __restrict__ bs,
-                                    SiPixelDigisLayoutSoAConstView digis,
+                                    SiPixelDigisSoAv2ConstView digis,
                                     uint32_t numElements,
                                     SiPixelClustersSoAConstView clusters,
                                     TrackingRecHitAlpakaSoAView<TrackerTraits> hits) const {


### PR DESCRIPTION
Update the `SiPixelDigisSoA` data formats and dictionaries:
  - rename `SiPixelDigisSoA` to `SiPixelDigisCollection`
  - rename `SiPixelDigisLayoutSoA` to `SiPixelDigisSoAv2`, and replace `SiPixelDigisLayout<>` with `SiPixelDigisSoAv2`
  - update the dictionaries

Update the `SiPixelDigiErrorsSoA` data formats and dictionaries:
  - rename `SiPixelDigiErrorsSoA` to `SiPixelDigiErrorsCollection`
  - rename `SiPixelDigiErrorsLayoutSoA` to `SiPixelDigiErrorsSoA`, and replace `SiPixelDigiErrorsLayout<>` with `SiPixelDigiErrorsSoA`
  - update the dictionaries
