### PR TITLE
update of HLT customisation with Alpaka pixel reco

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHitsSoAAlpaka.cc
@@ -1,37 +1,25 @@
-// -*- C++ -*-
-// Package:    SiPixelCompareRecHitsSoAAlpaka
-// Class:      SiPixelCompareRecHitsSoAAlpaka
-//
-/**\class SiPixelCompareRecHitsSoAAlpaka SiPixelCompareRecHitsSoAAlpaka.cc
-*/
-//
-// Author: Suvankar Roy Chowdhury, Alessandro Rossi
-//
-#include "DataFormats/Math/interface/approx_atan2.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-// DQM Histograming
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsLayout.h"
-// Geometry
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 template <typename T>
 class SiPixelCompareRecHitsSoAAlpaka : public DQMEDAnalyzer {
 public:
-  using HitSoA = TrackingRecHitAlpakaSoAView<T>;
   using HitsOnHost = TrackingRecHitAlpakaHost<T>;
 
   explicit SiPixelCompareRecHitsSoAAlpaka(const edm::ParameterSet&);
@@ -75,10 +63,10 @@ private:
   MonitorElement* hBposYDiff_;
   MonitorElement* hFposYDiff_;
 };
+
 //
 // constructors
 //
-
 template <typename T>
 SiPixelCompareRecHitsSoAAlpaka<T>::SiPixelCompareRecHitsSoAAlpaka(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
@@ -87,6 +75,7 @@ SiPixelCompareRecHitsSoAAlpaka<T>::SiPixelCompareRecHitsSoAAlpaka(const edm::Par
       tokenSoAHitsDevice_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsSrcGPU"))),
       topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
       mind2cut_(iConfig.getParameter<double>("minD2cut")) {}
+
 //
 // Begin Run
 //
@@ -104,7 +93,7 @@ void SiPixelCompareRecHitsSoAAlpaka<T>::analyze(const edm::Event& iEvent, const 
   const auto& rhsoaHandleHost = iEvent.getHandle(tokenSoAHitsHost_);
   const auto& rhsoaHandleDevice = iEvent.getHandle(tokenSoAHitsDevice_);
   if (not rhsoaHandleHost or not rhsoaHandleDevice) {
-    edm::LogWarning out("SiPixelCompareRecHitSoA");
+    edm::LogWarning out("SiPixelCompareRecHitsSoAAlpaka");
     if (not rhsoaHandleHost) {
       out << "reference (Host) rechits not found; ";
     }
@@ -248,5 +237,6 @@ void SiPixelCompareRecHitsSoAAlpaka<T>::fillDescriptions(edm::ConfigurationDescr
 using SiPixelPhase1CompareRecHitsSoAAlpaka = SiPixelCompareRecHitsSoAAlpaka<pixelTopology::Phase1>;
 using SiPixelPhase2CompareRecHitsSoAAlpaka = SiPixelCompareRecHitsSoAAlpaka<pixelTopology::Phase2>;
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1CompareRecHitsSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelPhase2CompareRecHitsSoAAlpaka);

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoAAlpaka.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelMonitorRecHitsSoAAlpaka.cc
@@ -1,39 +1,25 @@
-// -*- C++ -*-
-///bookLayer
-// Package:    SiPixelMonitorRecHitsSoAAlpaka
-// Class:      SiPixelMonitorRecHitsSoAAlpaka
-//
-/**\class SiPixelMonitorRecHitsSoAAlpaka SiPixelMonitorRecHitsSoAAlpaka.cc
-*/
-//
-// Author: Suvankar Roy Chowdhury, Alessandro Rossi
-//
-#include "DataFormats/Math/interface/approx_atan2.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-// DQM Histograming
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHitSoAHost.h"
-#include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHitsUtilities.h"
-// Geometry
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitSoAHost.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 template <typename T>
 class SiPixelMonitorRecHitsSoAAlpaka : public DQMEDAnalyzer {
 public:
-  using HitSoA = TrackingRecHitSoAView<T>;
-  using HitsOnHost = TrackingRecHitSoAHost<T>;
+  using HitsOnHost = TrackingRecHitAlpakaHost<T>;
 
   explicit SiPixelMonitorRecHitsSoAAlpaka(const edm::ParameterSet&);
   ~SiPixelMonitorRecHitsSoAAlpaka() override = default;
@@ -75,13 +61,13 @@ private:
 //
 // constructors
 //
-
 template <typename T>
 SiPixelMonitorRecHitsSoAAlpaka<T>::SiPixelMonitorRecHitsSoAAlpaka(const edm::ParameterSet& iConfig)
     : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
       tokenSoAHitsCPU_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsSrc"))),
       topFolderName_(iConfig.getParameter<std::string>("TopFolderName")) {}
+
 //
 // Begin Run
 //
@@ -98,7 +84,7 @@ template <typename T>
 void SiPixelMonitorRecHitsSoAAlpaka<T>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& rhsoaHandle = iEvent.getHandle(tokenSoAHitsCPU_);
   if (!rhsoaHandle.isValid()) {
-    edm::LogWarning("SiPixelMonitorRecHitsSoAAlpaka") << "No RecHits SoA found \n returning!" << std::endl;
+    edm::LogWarning("SiPixelMonitorRecHitsSoAAlpaka") << "No RecHits SoA found \n returning!";
     return;
   }
   auto const& rhsoa = *rhsoaHandle;
@@ -205,5 +191,6 @@ void SiPixelMonitorRecHitsSoAAlpaka<T>::fillDescriptions(edm::ConfigurationDescr
 using SiPixelPhase1MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::Phase1>;
 using SiPixelPhase2MonitorRecHitsSoAAlpaka = SiPixelMonitorRecHitsSoAAlpaka<pixelTopology::Phase2>;
 
+#include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SiPixelPhase1MonitorRecHitsSoAAlpaka);
 DEFINE_FWK_MODULE(SiPixelPhase2MonitorRecHitsSoAAlpaka);

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -1,43 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-from HLTrigger.Configuration.common import *
-
-def customiseHLTforTestingDQMGPUvsCPU(process):
-    '''Ad-hoc changes to test HLT config containing only DQM_PixelReconstruction_v and DQMGPUvsCPU stream
-    '''
-    if hasattr(process, 'hltDatasetDQMGPUvsCPU'):
-        process.hltDatasetDQMGPUvsCPU.triggerConditions = ['DQM_PixelReconstruction_v*']
-
-    # remove FinalPaths running OutputModules, except for the DQMGPUvsCPU one
-    finalPathsToRemove = []
-    for fpath in process.finalpaths_():
-        if 'DQMGPUvsCPU' not in fpath:
-            finalPathsToRemove += [fpath]
-    for fpath in finalPathsToRemove:
-        process.__delattr__(fpath)
-
-#    # add DQMIO output file
-#    if not hasattr(process, 'DQMStore'):
-#        process.load("DQMServices.Core.DQMStore_cfi")
-#
-#    if not hasattr(process, 'dqmOutput'):
-#        process.dqmOutput = cms.OutputModule("DQMRootOutputModule",
-#            fileName = cms.untracked.string("DQMIO.root")
-#        )
-#
-#    if not hasattr(process, 'DQMOutput'):
-#        process.DQMOutput = cms.FinalPath( process.dqmOutput )
-#        process.schedule.append( process.DQMOutput )
-
-    return process
-
-def customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal(process):
+def customizeHLTforDQMGPUvsCPUPixel(process):
     '''Ad-hoc changes to test HLT config containing only DQM_PixelReconstruction_v and DQMGPUvsCPU stream
        only up to the Pixel Local Reconstruction
     '''
-    process = customiseHLTforTestingDQMGPUvsCPU(process)
+    dqmPixelRecoPathName = None
+    for pathName in process.paths_():
+        if pathName.startswith('DQM_PixelReconstruction_v'):
+            dqmPixelRecoPathName = pathName
+            break
 
-    if not hasattr(process, 'HLTDoLocalPixelTask'):
+    if dqmPixelRecoPathName == None:
         return process
 
     process.hltPixelConsumerGPU.eventProducts = [
@@ -46,11 +19,12 @@ def customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal(process):
         'hltSiPixelDigiErrorsLegacyFormat',
         'hltSiPixelRecHits',
         'hltSiPixelRecHitsLegacyFormat',
+#        'hltPixelTracks',
     ]
 
     process.hltPixelConsumerCPU.eventProducts = []
-#    for foo in process.hltPixelConsumerGPU.eventProducts:
-#        process.hltPixelConsumerCPU.eventProducts += [foo+'CPUSerial']
+    for foo in process.hltPixelConsumerGPU.eventProducts:
+        process.hltPixelConsumerCPU.eventProducts += [foo+'CPUSerial']
 
     # modify EventContent of DQMGPUvsCPU stream
     if hasattr(process, 'hltOutputDQMGPUvsCPU'):
@@ -64,16 +38,48 @@ def customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal(process):
 #            'keep *RecHit*_hltSiPixelRecHitsCPUSerial_*_*',
         ]
 
-    # empty HLTRecopixelvertexingSequence until we add tracks and vertices
-    process.HLTRecopixelvertexingSequence = cms.Sequence()
+    # PixelRecHits: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
+    process.hltSiPixelRecHitsSoAMonitorCPU = cms.EDProducer('SiPixelPhase1MonitorRecHitsSoAAlpaka',
+        pixelHitsSrc = cms.InputTag( 'hltSiPixelRecHitsCPUSerial' ),
+        TopFolderName = cms.string( 'SiPixelHeterogeneous/PixelRecHitsCPU' )
+    )
 
-    # create CPU version of LocalPixelRecoSequence, and add it to HLTDQMPixelReconstruction
-    process.HLTDoLocalPixelSequenceCPUSerial = cms.Sequence( process.HLTDoLocalPixelTaskCPUSerial )
-    process.HLTDQMPixelReconstruction.insert(0, process.HLTDoLocalPixelSequenceCPUSerial)
+    # PixelRecHits: monitor of GPU product (Alpaka backend: '')
+    process.hltSiPixelRecHitsSoAMonitorGPU = cms.EDProducer('SiPixelPhase1MonitorRecHitsSoAAlpaka',
+        pixelHitsSrc = cms.InputTag( 'hltSiPixelRecHits' ),
+        TopFolderName = cms.string( 'SiPixelHeterogeneous/PixelRecHitsGPU' )
+    )
+
+    # PixelRecHits: 'GPUvsCPU' comparisons
+    process.hltSiPixelRecHitsSoACompareGPUvsCPU = cms.EDProducer('SiPixelPhase1CompareRecHitsSoAAlpaka',
+        pixelHitsSrcCPU = cms.InputTag( 'hltSiPixelRecHitsCPUSerial' ),
+        pixelHitsSrcGPU = cms.InputTag( 'hltSiPixelRecHits' ),
+        topFolderName = cms.string( 'SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU' ),
+        minD2cut = cms.double( 1.0E-4 )
+    )
+
+    process.HLTDQMPixelReconstruction = cms.Sequence(
+        process.hltSiPixelRecHitsSoAMonitorCPU
+      + process.hltSiPixelRecHitsSoAMonitorGPU
+      + process.hltSiPixelRecHitsSoACompareGPUvsCPU
+    )
+
+    # Add CPUSerial sequences to DQM_PixelReconstruction_v Path
+    dqmPixelRecoPath = getattr(process, dqmPixelRecoPathName)
+    try:
+        dqmPixelRecoPathIndex = dqmPixelRecoPath.index(process.HLTRecopixelvertexingSequence) + 1
+        for cpuSeqName in [
+            'HLTDoLocalPixelCPUSerialSequence',
+            'HLTRecopixelvertexingCPUSerialSequence',
+        ]:
+            dqmPixelRecoPath.insert(dqmPixelRecoPathIndex, getattr(process, cpuSeqName))
+            dqmPixelRecoPathIndex += 1
+    except:
+        dqmPixelRecoPathIndex = None
 
     return process
 
-def customiseHLTforAlpakaPixelRecoLocal(process):
+def customizeHLTforAlpakaPixelRecoLocal(process):
     '''Customisation to introduce the Local Pixel Reconstruction in Alpaka
     '''
     process.hltESPSiPixelCablingSoA = cms.ESProducer('SiPixelCablingSoAESProducer@alpaka',
@@ -108,8 +114,8 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     #  - reco::BeamSpot
     # produces
     #  - BeamSpotDeviceProduct
-    process.hltOnlineBeamSpotDevice = cms.EDProducer("BeamSpotDeviceProducer@alpaka",
-        src = cms.InputTag("hltOnlineBeamSpot"),
+    process.hltOnlineBeamSpotDevice = cms.EDProducer('BeamSpotDeviceProducer@alpaka',
+        src = cms.InputTag('hltOnlineBeamSpot'),
         alpaka = cms.untracked.PSet(
             backend = cms.untracked.string('')
         )
@@ -151,8 +157,8 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
         storeDigis = cms.bool(False)
     )
 
-    process.hltSiPixelClustersCache = cms.EDProducer("SiPixelClusterShapeCacheProducer",
-        src = cms.InputTag( "hltSiPixelClustersLegacyFormat" ),
+    process.hltSiPixelClustersCache = cms.EDProducer('SiPixelClusterShapeCacheProducer',
+        src = cms.InputTag( 'hltSiPixelClustersLegacyFormat' ),
         onDemand = cms.bool( False )
     )
 
@@ -163,11 +169,11 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     # produces
     #  - edm::DetSetVector<SiPixelRawDataError>
     #  - DetIdCollection
-    #  - DetIdCollection, "UserErrorModules"
+    #  - DetIdCollection, 'UserErrorModules'
     #  - edmNew::DetSetVector<PixelFEDChannel>
-    process.hltSiPixelDigiErrorsLegacyFormat = cms.EDProducer("SiPixelDigiErrorsFromSoA",
-        digiErrorSoASrc = cms.InputTag("hltSiPixelClusters"),
-        fmtErrorsSoASrc = cms.InputTag("hltSiPixelClusters"),
+    process.hltSiPixelDigiErrorsLegacyFormat = cms.EDProducer('SiPixelDigiErrorsFromSoA',
+        digiErrorSoASrc = cms.InputTag('hltSiPixelClusters'),
+        fmtErrorsSoASrc = cms.InputTag('hltSiPixelClusters'),
         CablingMapLabel = cms.string(''),
         UsePhase1 = cms.bool(True),
         ErrorList = cms.vint32(29),
@@ -181,7 +187,7 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     #  - SiPixelDigisCollection
     # produces
     #  - TrackingRecHitAlpakaCollection<TrackerTraits>
-    process.hltSiPixelRecHits = cms.EDProducer("SiPixelRecHitAlpakaPhase1@alpaka",
+    process.hltSiPixelRecHits = cms.EDProducer('SiPixelRecHitAlpakaPhase1@alpaka',
         beamSpot = cms.InputTag('hltOnlineBeamSpotDevice'),
         src = cms.InputTag('hltSiPixelClusters'),
         CPE = cms.string('PixelCPEFast'),
@@ -225,8 +231,8 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
     )
 
     process.hltSiPixelDigiErrorsLegacyFormatCPUSerial = process.hltSiPixelDigiErrorsLegacyFormat.clone(
-        digiErrorSoASrc = "hltSiPixelClustersCPUSerial",
-        fmtErrorsSoASrc = "hltSiPixelClustersCPUSerial",
+        digiErrorSoASrc = 'hltSiPixelClustersCPUSerial',
+        fmtErrorsSoASrc = 'hltSiPixelClustersCPUSerial',
     )
 
     process.hltSiPixelRecHitsCPUSerial = process.hltSiPixelRecHits.clone(
@@ -240,7 +246,7 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
         src = 'hltSiPixelClustersLegacyFormatCPUSerial',
     )
 
-    process.HLTDoLocalPixelTaskCPUSerial = cms.ConditionalTask(
+    process.HLTDoLocalPixelCPUSerialTask = cms.ConditionalTask(
         process.hltOnlineBeamSpotDeviceCPUSerial,
         process.hltSiPixelClustersCPUSerial,
         process.hltSiPixelClustersLegacyFormatCPUSerial,
@@ -249,9 +255,11 @@ def customiseHLTforAlpakaPixelRecoLocal(process):
         process.hltSiPixelRecHitsLegacyFormatCPUSerial,
     )
 
+    process.HLTDoLocalPixelCPUSerialSequence = cms.Sequence( process.HLTDoLocalPixelCPUSerialTask )
+
     return process
 
-def customiseHLTforAlpakaPixelRecoTracking(process):
+def customizeHLTforAlpakaPixelRecoTracking(process):
     '''Customisation to introduce the Pixel-Track Reconstruction in Alpaka
     '''
 
@@ -260,7 +268,7 @@ def customiseHLTforAlpakaPixelRecoTracking(process):
     #  - TrackingRecHitAlpakaCollection<TrackerTraits>
     # produces
     #  - TkSoADevice
-    process.hltPixelTracks = cms.EDProducer("CAHitNtupletAlpakaPhase1@alpaka",
+    process.hltPixelTracks = cms.EDProducer('CAHitNtupletAlpakaPhase1@alpaka',
         pixelRecHitSrc = cms.InputTag('hltSiPixelRecHits'),
         ptmin = cms.double(0.89999997615814209),
         CAThetaCutBarrel = cms.double(0.0020000000949949026),
@@ -301,13 +309,33 @@ def customiseHLTforAlpakaPixelRecoTracking(process):
         )
     )
 
+    process.hltPixelTracksCPUSerial = process.hltPixelTracks.clone(
+        pixelRecHitSrc = 'hltSiPixelRecHits',
+        alpaka = dict( backend = 'serial_sync' )
+    )
+
+    process.HLTRecoPixelTracksTask = cms.ConditionalTask(
+#         process.hltPixelTracks,
+    )
+
+    process.HLTRecoPixelTracksCPUSerialTask = cms.ConditionalTask(
+#         process.hltPixelTracksCPUSerial,
+    )
+
+    process.HLTRecoPixelTracksCPUSerialSequence = cms.Sequence( process.HLTRecoPixelTracksCPUSerialTask )
+
+    return process
+
+def customizeHLTforAlpakaPixelRecoVertexing(process):
+    '''Customisation to introduce the Pixel-Vertex Reconstruction in Alpaka
+    '''
+
     # alpaka EDProducer
     # consumes
     #  - TkSoADevice
     # produces
     #  - ZVertexDevice
     process.hltPixelVertices = cms.EDProducer('PixelVertexProducerAlpakaPhase1@alpaka',
-        onGPU = cms.bool(True),
         oneKernel = cms.bool(True),
         useDensity = cms.bool(True),
         useDBSCAN = cms.bool(False),
@@ -318,33 +346,43 @@ def customiseHLTforAlpakaPixelRecoTracking(process):
         chi2max = cms.double(9),
         PtMin = cms.double(0.5),
         PtMax = cms.double(75),
-        pixelTrackSrc = cms.InputTag('pixelTracksCUDA'),
+        pixelTrackSrc = cms.InputTag('hltPixelTracks'),
         # autoselect the alpaka backend
         alpaka = cms.untracked.PSet(
             backend = cms.untracked.string('')
         )
     )
 
+    process.hltPixelVerticesCPUSerial = process.hltPixelVertices.clone(
+        pixelTrackSrc = 'hltPixelTracksCPUSerial',
+        alpaka = dict( backend = 'serial_sync' )
+    )
+
+    process.HLTRecopixelvertexingTask = cms.ConditionalTask(
+        process.HLTRecoPixelTracksTask,
+    )
+
+    process.HLTRecopixelvertexingCPUSerialTask = cms.ConditionalTask(
+        process.HLTRecoPixelTracksCPUSerialTask,
+    )
+
+    process.HLTRecopixelvertexingCPUSerialSequence = cms.Sequence( process.HLTRecopixelvertexingCPUSerialTask )
+
     return process
 
-def customiseHLTforAlpakaPixelRecoVertexing(process):
-    '''Customisation to introduce the Pixel-Vertex Reconstruction in Alpaka
-    '''
-    return process
-
-def customiseHLTforAlpakaPixelReco(process):
+def customizeHLTforAlpakaPixelReco(process):
     '''Customisation to introduce the Pixel Local+Track+Vertex Reconstruction in Alpaka
     '''
     process.load('Configuration.StandardSequences.Accelerators_cff')
     process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
 
-    process = customiseHLTforAlpakaPixelRecoLocal(process)
-#    process = customiseHLTforAlpakaPixelRecoTracking(process)
-#    process = customiseHLTforAlpakaPixelRecoVertexing(process)
+    process = customizeHLTforAlpakaPixelRecoLocal(process)
+    process = customizeHLTforAlpakaPixelRecoTracking(process)
+    process = customizeHLTforAlpakaPixelRecoVertexing(process)
     return process
 
 def customizeHLTforPatatrack(process):
-    '''Customise HLT configuration introducing latest Patatrack developments
+    '''Customize HLT configuration introducing latest Patatrack developments
     '''
-    process = customiseHLTforAlpakaPixelReco(process)
+    process = customizeHLTforAlpakaPixelReco(process)
     return process

--- a/HLTrigger/Configuration/test/testHLTWithAlpakaPixelReco.sh
+++ b/HLTrigger/Configuration/test/testHLTWithAlpakaPixelReco.sh
@@ -10,13 +10,35 @@ hltGetConfiguration /frozen/2023/2e34/v1.2/HLT \
   --paths DQM_PixelReco*,*DQMGPUvsCPU* \
   --input /store/data/Run2023C/EphemeralHLTPhysics0/RAW/v1/000/368/822/00000/6e1268da-f96a-49f6-a5f0-89933142dd89.root \
   --customise \
-HLTrigger/Configuration/customizeHLTforPatatrack.customiseHLTforAlpakaPixelReco,\
-HLTrigger/Configuration/customizeHLTforPatatrack.customiseHLTforTestingDQMGPUvsCPUPixelOnlyUpToLocal \
+HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforPatatrack,\
+HLTrigger/Configuration/customizeHLTforPatatrack.customizeHLTforDQMGPUvsCPUPixel \
   > hlt.py
 
 cat <<EOF >> hlt.py
 process.options.numberOfThreads = 1
 process.options.numberOfStreams = 0
+
+del process.MessageLogger
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+
+# assign only DQM_PixelReconstruction_v to the DQMGPUvsCPU Primary Dataset
+process.hltDatasetDQMGPUvsCPU.triggerConditions = ['DQM_PixelReconstruction_v*']
+
+# remove FinalPaths running OutputModules, except for the DQMGPUvsCPU and DQM ones
+finalPathsToRemove = []
+for fpath in process.finalpaths_():
+    if fpath not in ['DQMOutput', 'DQMGPUvsCPUOutput']:
+        finalPathsToRemove += [fpath]
+for fpath in finalPathsToRemove:
+    process.__delattr__(fpath)
+
+# do not produce output of DQM stream (not needed)
+del process.hltOutputDQM
+
+# rename DQMIO output file
+process.dqmOutput.fileName = '___JOBNAME____DQMIO.root'
+
+# rename output of DQMGPUvsCPU stream
 process.hltOutputDQMGPUvsCPU.fileName = '___JOBNAME___.root'
 EOF
 


### PR DESCRIPTION
 - Restructured a bit the python customisation and bash script to run an HLT menu customised with the Alpaka pixel reco.
 - The customisation still goes only up to PixelRecHits (with both GPU and CPU-serial). Now it also includes the DQM modules for PixelRecHits.
 - The DQM modules currently complain, maybe because of a mismatch between the input collection and the type of the collection consumed by the DQM plugin.

```
%MSG-w SiPixelMonitorRecHitsSoAAlpaka:   SiPixelPhase1MonitorRecHitsSoAAlpaka:hltSiPixelRecHitsSoAMonitorGPU  30-Jun-2023 09:44:24 CEST Run: 368822 Event: 390960755
No RecHits SoA found
 returning!
%MSG
%MSG-w SiPixelMonitorRecHitsSoAAlpaka:   SiPixelPhase1MonitorRecHitsSoAAlpaka:hltSiPixelRecHitsSoAMonitorCPU  30-Jun-2023 09:44:24 CEST Run: 368822 Event: 390960755
No RecHits SoA found
 returning!
%MSG
```
